### PR TITLE
[#7] 직원 이력 관리 도메인 정의 및 검색 기능 기본 구조 구현

### DIFF
--- a/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
+++ b/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
@@ -1,0 +1,22 @@
+package com.hrbank.dto.employeeChangeLog;
+
+import com.hrbank.enums.EmployeeChangeLogType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmployeeChangeLogSearchRequest {
+  private String employeeNumber;
+  private EmployeeChangeLogType type;
+  private String memo;
+  private String ipAddress;
+  private LocalDateTime atFrom;
+  private LocalDateTime atTo;
+}
+

--- a/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
+++ b/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
@@ -5,10 +5,8 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class EmployeeChangeLogSearchRequest {

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
@@ -25,7 +25,7 @@ public class EmployeeChangeLog {
 
   @Id
   @GeneratedValue
-  private UUID id;
+  private Long id;
 
   // 유형
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
@@ -12,15 +12,13 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmployeeChangeLog {
 
   @Id
@@ -33,12 +31,15 @@ public class EmployeeChangeLog {
   private EmployeeChangeLogType type;
 
   // 사번
+  @Column(name="employee_number", nullable = false)
   private String employeeNumber;
 
   // 메모
+  @Column(columnDefinition = "TEXT")
   private String memo;
 
   // IP 주소
+  @Column(nullable = false)
   private String ipAddress;
 
   // 시간
@@ -47,4 +48,20 @@ public class EmployeeChangeLog {
   // change_log_diffs, 변경 상세 정보 저장
   @OneToMany(mappedBy = "changeLog", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<EmployeeChangeLogDetail> details = new ArrayList<>();
+
+  // 명시적 생성자
+  public EmployeeChangeLog(EmployeeChangeLogType type, String employeeNumber, String memo, String ipAddress, LocalDateTime at) {
+    this.type = type;
+    this.employeeNumber = employeeNumber;
+    this.memo = memo;
+    this.ipAddress = ipAddress;
+    this.at = at;
+  }
+
+  // 필요한 경우 detail 추가 메서드
+  public void addDetail(EmployeeChangeLogDetail detail) {
+    details.add(detail);
+    detail.setChangeLog(this); // 양방향 연관관계 유지
+  }
+
 }

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "change_logs")
 public class EmployeeChangeLog {
 
   @Id

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLog.java
@@ -1,0 +1,50 @@
+package com.hrbank.entity;
+
+import com.hrbank.enums.EmployeeChangeLogType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmployeeChangeLog {
+
+  @Id
+  @GeneratedValue
+  private UUID id;
+
+  // 유형
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private EmployeeChangeLogType type;
+
+  // 사번
+  private String employeeNumber;
+
+  // 메모
+  private String memo;
+
+  // IP 주소
+  private String ipAddress;
+
+  // 시간
+  private LocalDateTime at;
+
+  // change_log_diffs, 변경 상세 정보 저장
+  @OneToMany(mappedBy = "changeLog", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<EmployeeChangeLogDetail> details = new ArrayList<>();
+}

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "change_log_diffs")
 public class EmployeeChangeLogDetail {
 
   @Id

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
@@ -7,15 +7,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmployeeChangeLogDetail {
 
   @Id
@@ -24,12 +23,22 @@ public class EmployeeChangeLogDetail {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "change_log_id")
+  @Setter(AccessLevel.PACKAGE) // or PROTECTED
   private EmployeeChangeLog changeLog;
 
   @Column(name = "property_name")
   private String propertyName;
 
+  @Column(columnDefinition = "TEXT")
   private String before;
 
+  @Column(columnDefinition = "TEXT")
   private String after;
+
+  public EmployeeChangeLogDetail(EmployeeChangeLog changeLog, String propertyName, String before, String after) {
+    this.changeLog = changeLog;
+    this.propertyName = propertyName;
+    this.before = before;
+    this.after = after;
+  }
 }

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
@@ -20,7 +20,7 @@ public class EmployeeChangeLogDetail {
 
   @Id
   @GeneratedValue
-  private UUID id;
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "change_log_id")

--- a/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
+++ b/src/main/java/com/hrbank/entity/EmployeeChangeLogDetail.java
@@ -1,0 +1,35 @@
+package com.hrbank.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmployeeChangeLogDetail {
+
+  @Id
+  @GeneratedValue
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "change_log_id")
+  private EmployeeChangeLog changeLog;
+
+  @Column(name = "property_name")
+  private String propertyName;
+
+  private String before;
+
+  private String after;
+}

--- a/src/main/java/com/hrbank/enums/EmployeeChangeLogType.java
+++ b/src/main/java/com/hrbank/enums/EmployeeChangeLogType.java
@@ -1,0 +1,5 @@
+package com.hrbank.enums;
+
+public enum EmployeeChangeLogType {
+    CREATED, UPDATED, DELETED
+}

--- a/src/main/java/com/hrbank/repository/EmployeeChangeLogRepository.java
+++ b/src/main/java/com/hrbank/repository/EmployeeChangeLogRepository.java
@@ -1,0 +1,9 @@
+package com.hrbank.repository;
+
+import com.hrbank.entity.EmployeeChangeLog;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface EmployeeChangeLogRepository extends JpaRepository<EmployeeChangeLog, UUID>, JpaSpecificationExecutor<EmployeeChangeLog> {
+}

--- a/src/main/java/com/hrbank/repository/specification/EmployeeChangeLogSpecification.java
+++ b/src/main/java/com/hrbank/repository/specification/EmployeeChangeLogSpecification.java
@@ -1,0 +1,42 @@
+package com.hrbank.repository.specification;
+
+import com.hrbank.entity.EmployeeChangeLog;
+import com.hrbank.enums.EmployeeChangeLogType;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.domain.Specification;
+
+public class EmployeeChangeLogSpecification {
+
+  public static Specification<EmployeeChangeLog> employeeNumberContains(String keyword) {
+    return (root, query, cb) ->
+        keyword == null || keyword.isBlank()
+            ? null
+            : cb.like(root.get("employeeNumber"), "%" + keyword + "%");
+  }
+
+  public static Specification<EmployeeChangeLog> memoContains(String keyword) {
+    return (root, query, cb) ->
+        keyword == null || keyword.isBlank()
+            ? null
+            : cb.like(root.get("memo"), "%" + keyword + "%");
+  }
+
+  public static Specification<EmployeeChangeLog> ipAddressContains(String keyword) {
+    return (root, query, cb) ->
+        keyword == null || keyword.isBlank()
+            ? null
+            : cb.like(root.get("ipAddress"), "%" + keyword + "%");
+  }
+
+  public static Specification<EmployeeChangeLog> typeEquals(EmployeeChangeLogType type) {
+    return (root, query, cb) ->
+        type == null ? null : cb.equal(root.get("type"), type);
+  }
+
+  public static Specification<EmployeeChangeLog> atBetween(LocalDateTime start, LocalDateTime end) {
+    return (root, query, cb) ->
+        (start == null || end == null)
+            ? null
+            : cb.between(root.get("at"), start, end);
+  }
+}

--- a/src/main/java/com/hrbank/service/EmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/EmployeeChangeLogService.java
@@ -1,0 +1,15 @@
+package com.hrbank.service;
+
+import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
+import com.hrbank.entity.EmployeeChangeLog;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EmployeeChangeLogService {
+
+  Page<EmployeeChangeLog> searchLogs(EmployeeChangeLogSearchRequest request, Pageable pageable);
+
+  Optional<EmployeeChangeLog> findWithDetailsById(UUID id);
+}

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
@@ -1,0 +1,39 @@
+package com.hrbank.service.basic;
+
+import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
+import com.hrbank.entity.EmployeeChangeLog;
+import com.hrbank.repository.EmployeeChangeLogRepository;
+import com.hrbank.repository.specification.EmployeeChangeLogSpecification;
+import com.hrbank.service.EmployeeChangeLogService;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {
+
+  private final EmployeeChangeLogRepository repository;
+
+  @Override
+  public Page<EmployeeChangeLog> searchLogs(EmployeeChangeLogSearchRequest request, Pageable pageable) {
+    Specification<EmployeeChangeLog> spec = Specification.<EmployeeChangeLog>where(null)
+        .and(EmployeeChangeLogSpecification.employeeNumberContains(request.getEmployeeNumber()))
+        .and(EmployeeChangeLogSpecification.memoContains(request.getMemo()))
+        .and(EmployeeChangeLogSpecification.ipAddressContains(request.getIpAddress()))
+        .and(EmployeeChangeLogSpecification.typeEquals(request.getType()))
+        .and(EmployeeChangeLogSpecification.atBetween(request.getAtFrom(), request.getAtTo()));
+
+    return repository.findAll(spec, pageable);
+  }
+
+  @Override
+  public Optional<EmployeeChangeLog> findWithDetailsById(UUID id) {
+    return repository.findById(id); // 추후 fetch join 필요하면 custom query로 변경
+  }
+}
+


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feat/07-employee-log-setup -> main

### 변경 사항
- 직원 이력 관리 기능을 위한 핵심 도메인 정의
  - `EmployeeChangeLog`, `EmployeeChangeLogDetail` 설계
  - ID 타입은 프로젝트 전체 일관성을 위해 UUID → Long으로 통일
- 이력 유형 구분을 위한 Enum 정의 (`EmployeeChangeLogType`)
- 이력 저장을 위한 Repository (`JpaSpecificationExecutor` 적용)
- 동적 검색 조건 대응을 위한 Specification 클래스 구성
- 검색 요청 DTO (`EmployeeChangeLogSearchRequest`) 작성
- 기본 조회용 서비스 (`EmployeeChangeLogService`, `Basic~`) 인터페이스 및 구현체 구성

- Closes #7