### PR TITLE
[#9] BinaryContent 엔터티 & 관련 파일 추가 및 파일 셍성 기능 추가

### DIFF
--- a/src/main/java/com/hrbank/dto/binarycontent/BinaryContentCreateRequest.java
+++ b/src/main/java/com/hrbank/dto/binarycontent/BinaryContentCreateRequest.java
@@ -1,0 +1,15 @@
+package com.hrbank.dto.binarycontent;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record BinaryContentCreateRequest(
+    MultipartFile file
+) {
+
+  public static BinaryContentCreateRequest of(MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      return null;
+    }
+    return new BinaryContentCreateRequest(file);
+  }
+}

--- a/src/main/java/com/hrbank/dto/binarycontent/BinaryContentDto.java
+++ b/src/main/java/com/hrbank/dto/binarycontent/BinaryContentDto.java
@@ -1,0 +1,10 @@
+package com.hrbank.dto.binarycontent;
+
+public record BinaryContentDto(
+    Long id,
+    String fileName,
+    Long size,
+    String contentType
+) {
+
+}

--- a/src/main/java/com/hrbank/entity/BinaryContent.java
+++ b/src/main/java/com/hrbank/entity/BinaryContent.java
@@ -1,0 +1,37 @@
+package com.hrbank.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "binary_contents")
+public class BinaryContent {
+
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  @Column(name = "file_name", nullable = false)
+  private String fileName;
+
+  @Column(name = "content_type", nullable = false)
+  private String contentType;
+
+  @Column(nullable = false)
+  private Long size;
+
+  public BinaryContent(String fileName, String contentType, Long size) {
+    this.fileName = fileName;
+    this.contentType = contentType;
+    this.size = size;
+  }
+}

--- a/src/main/java/com/hrbank/entity/BinaryContent.java
+++ b/src/main/java/com/hrbank/entity/BinaryContent.java
@@ -7,11 +7,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @Table(name = "binary_contents")
 public class BinaryContent {

--- a/src/main/java/com/hrbank/mapper/BinaryContentMapper.java
+++ b/src/main/java/com/hrbank/mapper/BinaryContentMapper.java
@@ -1,0 +1,10 @@
+package com.hrbank.mapper;
+
+import com.hrbank.dto.binarycontent.BinaryContentDto;
+import com.hrbank.entity.BinaryContent;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BinaryContentMapper {
+  BinaryContentDto toDto(BinaryContent binaryContent);
+}

--- a/src/main/java/com/hrbank/repository/BinaryContentRepository.java
+++ b/src/main/java/com/hrbank/repository/BinaryContentRepository.java
@@ -1,0 +1,8 @@
+package com.hrbank.repository;
+
+import com.hrbank.entity.BinaryContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BinaryContentRepository extends JpaRepository<BinaryContent, Long> {
+
+}

--- a/src/main/java/com/hrbank/service/BasicBinaryContentService.java
+++ b/src/main/java/com/hrbank/service/BasicBinaryContentService.java
@@ -1,0 +1,36 @@
+package com.hrbank.service;
+
+import com.hrbank.dto.binarycontent.BinaryContentCreateRequest;
+import com.hrbank.entity.BinaryContent;
+import com.hrbank.repository.BinaryContentRepository;
+import com.hrbank.storage.BinaryContentStorage;
+import io.swagger.v3.oas.annotations.servers.Server;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Server
+@RequiredArgsConstructor
+public class BasicBinaryContentService implements BinaryContentService {
+  private final BinaryContentRepository binaryContentRepository;
+  private final BinaryContentStorage binaryContentStorage;
+
+  @Override
+  @Transactional
+  public BinaryContent create(BinaryContentCreateRequest request) {
+    String originalFilename = request.file().getOriginalFilename();
+    String contentType = request.file().getContentType();
+    long size = request.file().getSize();
+    byte[] bytes;
+    try {
+      bytes = request.file().getBytes();
+    } catch (IOException e) {
+      throw new RuntimeException("파일 변환 중 오류 발생: " + e);
+    }
+    BinaryContent binaryContent = new BinaryContent(originalFilename, contentType, size);
+    binaryContentRepository.save(binaryContent);
+    binaryContentStorage.put(binaryContent.getId(), bytes);
+    return binaryContent;
+  }
+
+}

--- a/src/main/java/com/hrbank/service/BinaryContentService.java
+++ b/src/main/java/com/hrbank/service/BinaryContentService.java
@@ -1,0 +1,12 @@
+package com.hrbank.service;
+
+import com.hrbank.dto.binarycontent.BinaryContentCreateRequest;
+import com.hrbank.entity.BinaryContent;
+
+public interface BinaryContentService {
+  BinaryContent create(BinaryContentCreateRequest request);
+
+  //BinaryContentDto findById(Long id);
+
+  //void delete(Long id);
+}

--- a/src/main/java/com/hrbank/storage/BinaryContentStorage.java
+++ b/src/main/java/com/hrbank/storage/BinaryContentStorage.java
@@ -1,0 +1,44 @@
+package com.hrbank.storage;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "hrbank.storage.type", value = "local")
+public class BinaryContentStorage {
+  private final Path root;
+
+  public BinaryContentStorage(@Value(".hrbank/storage") Path root){
+    this.root = root;
+  }
+
+  @PostConstruct
+  public void init(){
+    if (!Files.exists(root)) {
+      try {
+        Files.createDirectories(root);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public void put(Long id, byte[] data){
+    Path filePath = root.resolve(id.toString());
+    if (Files.exists(filePath)) {
+      throw new RuntimeException("이미 존재하는 파일");
+    }
+    try (OutputStream fos = Files.newOutputStream(filePath)) {
+      fos.write(data);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feat/9-binaryContent-create -> main

### 변경 사항
- 파일 관리 기능을 위한 핵심 도메인 `BinaryContent` 정의
- 파일 저장을 위한 Repository(JpaRepository상속) 생성
- BinaryContentService인터페이스, BasicBinaryContentService클래스 생성
- 파일 저장 기능 구현을 위해 `BasicBinaryContentService`에 `create()`생성
- Closes #9 