### PR TITLE
[#15} 커서 기반 페이징 구현 + 스케쥴러 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
+    // CSV
+    implementation 'org.apache.commons:commons-csv:1.10.0'
+
     // Dev Tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/hrbank/dto/backup/BackupDto.java
+++ b/src/main/java/com/hrbank/dto/backup/BackupDto.java
@@ -10,7 +10,7 @@ public record BackupDto(
     Instant startedAt,
     Instant endedAt,
     BackupStatus status,
-    UUID fileId
+    Long fileId
 ) {
 
 }

--- a/src/main/java/com/hrbank/entity/Backup.java
+++ b/src/main/java/com/hrbank/entity/Backup.java
@@ -36,7 +36,7 @@ public class Backup {
   @Column(name = "started_at", nullable = false)
   private Instant startedAt;
 
-  @Column(name = "ended_at")
+  @Column(name = "ended_at", nullable = false)
   private Instant endedAt;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/hrbank/entity/Backup.java
+++ b/src/main/java/com/hrbank/entity/Backup.java
@@ -15,17 +15,16 @@ import java.time.Instant;;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
 @Entity
-@Data
+@Getter
 @Builder
 @Table(name = "backups")
 @AllArgsConstructor
 public class Backup {
 
-  public Backup() {
-
-  }
+  public Backup() {  }
 
   @Id
   @GeneratedValue
@@ -48,5 +47,16 @@ public class Backup {
   @JoinColumn(name = "file_id")
   private BinaryContent file;
 
+  public void completeBackup(BinaryContent file) {
+    this.status = BackupStatus.COMPLETED;
+    this.endedAt = Instant.now();
+    this.file = file;
+  }
+
+  public void failBackup(BinaryContent logFile) {
+    this.status = BackupStatus.FAILED;
+    this.endedAt = Instant.now();
+    this.file = logFile;
+  }
 
 }

--- a/src/main/java/com/hrbank/enums/EmployeeCsvHeader.java
+++ b/src/main/java/com/hrbank/enums/EmployeeCsvHeader.java
@@ -1,0 +1,5 @@
+package com.hrbank.enums;
+
+public enum EmployeeCsvHeader {
+  ID, 직원번호, 이름, 이메일, 부서, 직급, 입사일, 상태
+}

--- a/src/main/java/com/hrbank/enums/EmployeeCsvHeader.java
+++ b/src/main/java/com/hrbank/enums/EmployeeCsvHeader.java
@@ -1,5 +1,0 @@
-package com.hrbank.enums;
-
-public enum EmployeeCsvHeader {
-  ID, 직원번호, 이름, 이메일, 부서, 직급, 입사일, 상태
-}

--- a/src/main/java/com/hrbank/mapper/BackupMapper.java
+++ b/src/main/java/com/hrbank/mapper/BackupMapper.java
@@ -2,19 +2,12 @@ package com.hrbank.mapper;
 
 import com.hrbank.dto.backup.BackupDto;
 import com.hrbank.entity.Backup;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-public class BackupMapper {
-  public static BackupDto toDto(Backup entity) {
-    if (entity == null) return null;
+@Mapper(componentModel = "spring")
+public interface BackupMapper {
 
-    return new BackupDto(
-        entity.getId(),
-        entity.getWorker(),
-        entity.getStartedAt(),
-        entity.getEndedAt(),
-        entity.getStatus(),
-        entity.getFile() != null ? entity.getFile().getId() : null
-    );
-  }
-
+  @Mapping(source = "file.id", target = "fileId")
+  BackupDto toDto(Backup backup);
 }

--- a/src/main/java/com/hrbank/scheduler/BackupScheduler.java
+++ b/src/main/java/com/hrbank/scheduler/BackupScheduler.java
@@ -1,0 +1,20 @@
+package com.hrbank.scheduler;
+
+import com.hrbank.service.BackupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BackupScheduler {
+    private final BackupService backupService;
+
+  @Scheduled(cron = "0 0 * * * *") // 매 시간 정각
+  public void runHourlyBackup() {
+    log.info("Hourly backup triggered by scheduler");
+    backupService.runBackup("system");  // 작업자는 시스템
+  }
+}

--- a/src/main/java/com/hrbank/service/BackupService.java
+++ b/src/main/java/com/hrbank/service/BackupService.java
@@ -1,10 +1,16 @@
 package com.hrbank.service;
 
 import com.hrbank.dto.backup.BackupDto;
+import com.hrbank.dto.backup.CursorPageResponseBackupDto;
+import com.hrbank.enums.BackupStatus;
+import java.time.Instant;
 
 public interface BackupService {
 
-  //백업 수행
+  // 조건에 맞는 백업 목록 조회
+  CursorPageResponseBackupDto searchBackups(String worker, BackupStatus status, Instant from, Instant to, Long id, String cursor, Integer size, String sortField, String sortDirection);
+
+  // 백업 수행
   void runBackup(String requesterIp);
 
   // 백업 필요 여부 판단: 가장 최근 완료 이후 변경 있으면 true

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -222,7 +222,7 @@ public class BasicBackupService implements BackupService {
 
     try (
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(csvFile), StandardCharsets.UTF_8));
-        CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader("ID", "직원번호", "이름", "이메일", "부서", "직급", "입사일", "상태"))
+        CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(EmployeeCsvHeader.class))
     ) {
       for (Employee employee : employees) {
         csvPrinter.printRecord(

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -38,11 +38,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class BasicBackupService implements BackupService {
 
-  private BackupRepository backupRepository;
-  private BackupMapper backupMapper;
-  private EmployeeRepository employeeRepository;
-  private EmployeeChangeLogRepository employeeChangeLogRepository
-  private BinaryContentRepository binaryContentRepository;
+  private final BackupRepository backupRepository;
+  private final BackupMapper backupMapper;
+  private final EmployeeRepository employeeRepository;
+  private final EmployeeChangeLogRepository employeeChangeLogRepository
+  private final BinaryContentRepository binaryContentRepository;
 
   @Override
   public void runBackup(String requesterIp) {

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -2,26 +2,46 @@ package com.hrbank.service.basic;
 
 import com.hrbank.dto.backup.BackupDto;
 import com.hrbank.entity.Backup;
+import com.hrbank.entity.BinaryContent;
+import com.hrbank.entity.Employee;
 import com.hrbank.enums.BackupStatus;
 import com.hrbank.mapper.BackupMapper;
 import com.hrbank.repository.BackupRepository;
+import com.hrbank.repository.BinaryContentRepository;
+import com.hrbank.repository.EmployeeChangeLogRepository;
+import com.hrbank.repository.EmployeeRepository;
 import com.hrbank.service.BackupService;
 import jakarta.persistence.EntityNotFoundException;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class BasicBackupService implements BackupService {
 
   private BackupRepository backupRepository;
   private BackupMapper backupMapper;
   private EmployeeRepository employeeRepository;
+  private EmployeeChangeLogRepository employeeChangeLogRepository
   private BinaryContentRepository binaryContentRepository;
 
   @Override
@@ -69,7 +89,7 @@ public class BasicBackupService implements BackupService {
 
     // 특정 시간 이후 직원 업데이트 내역 확인
     // 추후 구현 필요
-    return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
+    return employeeChangeLogRepository.existsByUpdatedAtAfter(lastBackupTime);
   }
 
   @Override
@@ -92,9 +112,7 @@ public class BasicBackupService implements BackupService {
     BinaryContent file = binaryContentRepository.findById(fileId)
         .orElseThrow(() -> new EntityNotFoundException("파일을 찾을 수 없습니다."));
 
-    backup.setStatus(BackupStatus.COMPLETED);
-    backup.setEndedAt(Instant.now());
-    backup.setFile(file);
+    backup.completeBackup(file);
   }
 
   @Override
@@ -105,8 +123,73 @@ public class BasicBackupService implements BackupService {
     BinaryContent logFile = binaryContentRepository.findById(logFileId)
         .orElseThrow(() -> new EntityNotFoundException("로그 파일을 찾을 수 없습니다."));
 
-    backup.setStatus(BackupStatus.FAILED);
-    backup.setEndedAt(Instant.now());
-    backup.setFile(logFile);
+    backup.failBackup(logFile);
+  }
+
+  private Long generateBackupFile(Long backupId) {
+    try {
+      File file = createEmployeeCsv();
+      return storeAsBinary(file, "text/csv");
+    } catch (IOException e) {
+      log.error("직원 CSV 파일 생성 실패", e);
+      throw new RuntimeException("직원 CSV 파일 생성 중 오류 발생", e);
+    }
+  }
+
+  private Long saveErrorLogFile(Exception e) {
+    try {
+      File logFile = createErrorLogFile(e);
+      return storeAsBinary(logFile, "text/plain");
+    } catch (IOException ioException) {
+      log.error("에러 로그 파일 저장 실패", ioException);
+      throw new RuntimeException("에러 로그 파일 저장 실패", ioException);
+    }
+  }
+
+  // 직원 데이터를 CSV로 파일로 저장
+  private File createEmployeeCsv() throws IOException {
+    List<Employee> employees = employeeRepository.findAll();
+    File csvFile = File.createTempFile("employee-backup-", ".csv");
+
+    try (
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(csvFile), StandardCharsets.UTF_8));
+        CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader("ID", "직원번호", "이름", "이메일", "부서", "직급", "입사일", "상태"))
+    ) {
+      for (Employee employee : employees) {
+        csvPrinter.printRecord(
+            employee.getId(),
+            employee.getEmployeeNumber(),
+            employee.getName(),
+            employee.getEmail(),
+            employee.getDepartment() != null ? employee.getDepartment().getName() : "",
+            employee.getPosition(),
+            employee.getHireDate().toString(),
+            employee.getStatus()
+        );
+      }
+      csvPrinter.flush();
+    }
+
+    return csvFile;
+  }
+
+  // 예외를 .log 파일로 저장
+  private File createErrorLogFile(Exception e) throws IOException {
+    StringWriter sw = new StringWriter();
+    e.printStackTrace(new PrintWriter(sw));
+    String logContent = sw.toString();
+
+    File logFile = File.createTempFile("backup-error-", ".log");
+    Files.write(logFile.toPath(), logContent.getBytes(StandardCharsets.UTF_8));
+    return logFile;
+  }
+
+  // File을 BinaryContent로 저장하고 ID 반환
+  private Long storeAsBinary(File file, String contentType) throws IOException {
+    byte[] data = Files.readAllBytes(file.toPath());
+    BinaryContent binaryContent = new BinaryContent(file.getName(), contentType, (long) data.length);
+    return binaryContentRepository.save(binaryContent).getId();
   }
 }
+
+


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/15-backup-csv-scheduler -> main

### 이슈 번호
- close #15 

### 변경 사항
- 백업 목록 조회 기능 구현 (`searchBackups`)  
  - 다중 조건 필터링: `worker`, `status`, `from`, `to`  
  - 정렬 필드 및 방향: `startedAt`, `endedAt`, `ASC`/`DESC` 지원  
  - 커서 기반 페이지네이션 적용 (`cursor`, `nextCursor`, `nextIdAfter`)  
  - `size` 파라미터의 기본값 10 처리  

- 커서 인코딩/디코딩 헬퍼 함수 추가  
  - `encodeCursor(Long id)` – `{"id": <id>}` → Base64 인코딩  
  - `decodeCursor(String cursor)` – Base64 디코딩 후 JSON 파싱  

- 백업 스케줄러 등록 (`BackupScheduler`)  
  - `@Scheduled(cron = "0 0 * * * *")`로 매 시간 정각마다 자동 실행  
  - 시스템 요청자 `"system"`으로 `runBackup("system")` 호출

