### PR TITLE
[#27] 직원 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank/controller/EmployeeController.java
@@ -1,12 +1,18 @@
 package com.hrbank.controller;
 
 import com.hrbank.dto.employee.CursorPageResponseEmployeeDto;
+import com.hrbank.dto.employee.EmployeeDto;
 import com.hrbank.dto.employee.EmployeeSearchCondition;
+import com.hrbank.dto.employee.EmployeeUpdateRequest;
 import com.hrbank.service.EmployeeService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +26,16 @@ public class EmployeeController {
   @GetMapping
   public ResponseEntity<CursorPageResponseEmployeeDto> searchEmployees(@ModelAttribute EmployeeSearchCondition condition) {
     return ResponseEntity.ok(employeeService.searchEmployees(condition));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<EmployeeDto> updateEmployee(
+      @PathVariable Long id,
+      @RequestBody EmployeeUpdateRequest request,
+      HttpServletRequest httpRequest
+  ) {
+    String ip = httpRequest.getRemoteAddr();
+    EmployeeDto updated = employeeService.update(id, request, ip);
+    return ResponseEntity.ok(updated);
   }
 }

--- a/src/main/java/com/hrbank/dto/employee/EmployeeUpdateRequest.java
+++ b/src/main/java/com/hrbank/dto/employee/EmployeeUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.hrbank.dto.employee;
+
+import com.hrbank.enums.EmployeeStatus;
+import java.time.LocalDate;
+
+public record EmployeeUpdateRequest(
+    String name,
+    String email,
+    Long departmentId,
+    String position,
+    LocalDate hireDate,
+    EmployeeStatus status,
+    String memo,
+    Long profileImageId
+) {}

--- a/src/main/java/com/hrbank/entity/Employee.java
+++ b/src/main/java/com/hrbank/entity/Employee.java
@@ -1,5 +1,6 @@
 package com.hrbank.entity;
 
+import com.hrbank.enums.EmployeeStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -66,6 +67,18 @@ public class Employee {
   }
 
   // 상태 변경 메서드
+  public void updateName(String name) {
+    this.name = name;
+  }
+
+  public void updateEmail(String email) {
+    this.email = email;
+  }
+
+  public void updateHireDate(LocalDate hireDate) {
+    this.hireDate = hireDate;
+  }
+
   public void changeDepartment(Department newDepartment) {
     this.department = newDepartment;
   }

--- a/src/main/java/com/hrbank/service/EmployeeService.java
+++ b/src/main/java/com/hrbank/service/EmployeeService.java
@@ -1,8 +1,11 @@
 package com.hrbank.service;
 
 import com.hrbank.dto.employee.CursorPageResponseEmployeeDto;
+import com.hrbank.dto.employee.EmployeeDto;
 import com.hrbank.dto.employee.EmployeeSearchCondition;
+import com.hrbank.dto.employee.EmployeeUpdateRequest;
 
 public interface EmployeeService {
   CursorPageResponseEmployeeDto searchEmployees(EmployeeSearchCondition condition);
+  EmployeeDto update(Long id, EmployeeUpdateRequest request, String ip);
 }

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
@@ -1,8 +1,17 @@
 package com.hrbank.service.basic;
 
 import com.hrbank.dto.employee.CursorPageResponseEmployeeDto;
+import com.hrbank.dto.employee.EmployeeDto;
 import com.hrbank.dto.employee.EmployeeSearchCondition;
-import com.hrbank.repository.EmployeeRepositoryCustom;
+import com.hrbank.dto.employee.EmployeeUpdateRequest;
+import com.hrbank.entity.BinaryContent;
+import com.hrbank.entity.Department;
+import com.hrbank.entity.Employee;
+import com.hrbank.mapper.EmployeeMapper;
+import com.hrbank.repository.BinaryContentRepository;
+import com.hrbank.repository.DepartmentRepository;
+import com.hrbank.repository.EmployeeRepository;
+import com.hrbank.service.EmployeeChangeLogService;
 import com.hrbank.service.EmployeeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,10 +20,53 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BasicEmployeeService implements EmployeeService {
 
-  private final EmployeeRepositoryCustom employeeRepository;
+  private final EmployeeRepository employeeRepository;
+  private final DepartmentRepository departmentRepository;
+  private final BinaryContentRepository binaryContentRepository;
+  private final EmployeeMapper employeeMapper;
+  private final EmployeeChangeLogService changeLogService;
+
 
   @Override
   public CursorPageResponseEmployeeDto searchEmployees(EmployeeSearchCondition condition) {
     return employeeRepository.findAllWithFilter(condition);
+  }
+
+  @Override
+  public EmployeeDto update(Long id, EmployeeUpdateRequest request, String ip) {
+    Employee employee = employeeRepository.findById(id)
+        .orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
+
+    Department department = departmentRepository.findById(request.departmentId())
+        .orElseThrow(() -> new RestException(ErrorCode.DEPARTMENT_NOT_FOUND));
+
+    BinaryContent profileImage = null;
+    if (request.profileImageId() != null) {
+      profileImage = binaryContentRepository.findById(request.profileImageId())
+          .orElseThrow(() -> new RestException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
+    }
+    // RestException 나중에 머지 되면 바꿀 예정
+
+    // 기존 상태 보존
+    Employee before = new Employee(
+        employee.getName(), employee.getEmail(), employee.getEmployeeNumber(),
+        employee.getDepartment(), employee.getPosition(), employee.getHireDate(),
+        employee.getStatus()
+    );
+    before.changeProfileImage(employee.getProfileImage());
+
+    // 값 변경
+    employee.changeDepartment(department);
+    employee.changePosition(request.position());
+    employee.changeStatus(request.status());
+    employee.changeProfileImage(profileImage);
+    employee.updateName(request.name());
+    employee.updateEmail(request.email());
+    employee.updateHireDate(request.hireDate());
+
+    // 이력 로그 저장
+    changeLogService.saveChangeLog(before, employee, request.memo(), ip);
+
+    return employeeMapper.toDto(employee);
   }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/27-update-employee-v2 -> main

### 이슈 번호
- close #27 

### 변경 사항
- 직원 정보 수정 API 컨트롤러 추가
- 수정 요청을 처리하기 위한 서비스 로직 구현
- 존재하지 않는 직원 또는 부서에 대한 예외 처리 추가
- 예외 발생시 RestException 방식으로 처리 (머지되면 Enum에 추가 예정)

### 테스트 결과

