### PR TITLE
[#36] 백업 API 구현 및 서비스 개선

### DIFF
--- a/src/main/java/com/hrbank/controller/BackupController.java
+++ b/src/main/java/com/hrbank/controller/BackupController.java
@@ -1,0 +1,53 @@
+package com.hrbank.controller;
+
+import com.hrbank.dto.backup.BackupDto;
+import com.hrbank.dto.backup.CursorPageResponseBackupDto;
+import com.hrbank.enums.BackupStatus;
+import com.hrbank.service.BackupService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/backups")
+public class BackupController {
+  private final BackupService backupService;
+
+  @GetMapping
+  public ResponseEntity<CursorPageResponseBackupDto> getAllBackups(
+      @RequestParam(required = false) String worker,
+      @RequestParam(required = false) BackupStatus status,
+      @RequestParam(required = false)
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startedAtFrom,
+      @RequestParam(required = false)
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startedAtTo,
+      @RequestParam(required = false) Long idAfter,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false, defaultValue = "10") Integer size,
+      @RequestParam(required = false, defaultValue = "startedAt") String sortField,
+      @RequestParam(required = false, defaultValue = "DESC") String sortDirection
+  ){
+    CursorPageResponseBackupDto cursorPageResponseBackupDto = backupService.searchBackups(worker, status, startedAtFrom,startedAtTo,idAfter,cursor,size,sortField,sortDirection);
+    return ResponseEntity.ok(cursorPageResponseBackupDto);
+  }
+
+  @PostMapping
+  public ResponseEntity<BackupDto> createBackup(HttpServletRequest servletRequest){
+      BackupDto backupDto = backupService.runBackup(servletRequest.getRemoteAddr());
+      return ResponseEntity.ok(backupDto);
+  }
+
+  @GetMapping(value = "/latest")
+  public ResponseEntity<BackupDto> getLatestBackup(@RequestParam(required = false, defaultValue = "COMPLETED") BackupStatus status){
+    BackupDto backupDto = backupService.findLatestBackupByStatus(status);
+    return ResponseEntity.ok(backupDto);
+  }
+}

--- a/src/main/java/com/hrbank/service/BackupService.java
+++ b/src/main/java/com/hrbank/service/BackupService.java
@@ -10,6 +10,9 @@ public interface BackupService {
   // 조건에 맞는 백업 목록 조회
   CursorPageResponseBackupDto searchBackups(String worker, BackupStatus status, Instant from, Instant to, Long id, String cursor, Integer size, String sortField, String sortDirection);
 
+  // status한 가장 최근 백업 조회
+  BackupDto findLatestBackupByStatus(BackupStatus status);
+
   // 백업 수행
   BackupDto runBackup(String requesterIp);
 

--- a/src/main/java/com/hrbank/service/BackupService.java
+++ b/src/main/java/com/hrbank/service/BackupService.java
@@ -11,7 +11,7 @@ public interface BackupService {
   CursorPageResponseBackupDto searchBackups(String worker, BackupStatus status, Instant from, Instant to, Long id, String cursor, Integer size, String sortField, String sortDirection);
 
   // 백업 수행
-  void runBackup(String requesterIp);
+  BackupDto runBackup(String requesterIp);
 
   // 백업 필요 여부 판단: 가장 최근 완료 이후 변경 있으면 true
   boolean isBackupRequired();

--- a/src/main/java/com/hrbank/service/BackupService.java
+++ b/src/main/java/com/hrbank/service/BackupService.java
@@ -15,16 +15,4 @@ public interface BackupService {
 
   // 백업 수행
   BackupDto runBackup(String requesterIp);
-
-  // 백업 필요 여부 판단: 가장 최근 완료 이후 변경 있으면 true
-  boolean isBackupRequired();
-
-  // 백업 이력 생성
-  BackupDto createInProgressBackup(String requesterIp);
-
-  // 백업 성공 시 상태/종료시간/파일ID 갱신
-  void markBackupCompleted(Long backupId, Long fileId);
-
-  // 백업 실패 시 상태/종료시간/로그파일ID 갱신
-  void markBackupFailed(Long backupId, Long logFileId);
 }

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -64,7 +64,6 @@ public class BasicBackupService implements BackupService {
     filtered.sort(comparator);
 
     // 커서 디코딩 및 시작 인덱스 계산
-    int finalSize = (size == null || size <= 0) ? 10 : size;
     int startIndex = 0;
     Long cursorId = null;
 
@@ -80,7 +79,7 @@ public class BasicBackupService implements BackupService {
     }
 
     // 페이지 처리
-    int endIndex = Math.min(startIndex + finalSize, filtered.size());
+    int endIndex = Math.min(startIndex + size, filtered.size());
     List<BackupDto> page = filtered.subList(startIndex, endIndex).stream()
         .map(backupMapper::toDto)
         .toList();
@@ -93,7 +92,7 @@ public class BasicBackupService implements BackupService {
         page,
         nextCursor,
         nextIdAfter,
-        finalSize,
+        size,
         filtered.size(),
         hasNext
     );

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -101,7 +101,7 @@ public class BasicBackupService implements BackupService {
 
 
   @Override
-  public void runBackup(String requesterIp) {
+  public BackupDto runBackup(String requesterIp) {
     if (!isBackupRequired()) {
       // 백업 필요 없으면 SKIPPED 처리
       Backup skipped = Backup.builder()
@@ -111,7 +111,7 @@ public class BasicBackupService implements BackupService {
           .endedAt(Instant.now())
           .build();
       backupRepository.save(skipped);
-      return;
+      return backupMapper.toDto(skipped);
     }
 
     // 백업 이력 생성
@@ -132,6 +132,8 @@ public class BasicBackupService implements BackupService {
       // 실패 처리
       markBackupFailed(inProgress.id(), logFileId);
     }
+
+    return inProgress;
   }
 
   @Override

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -99,6 +99,15 @@ public class BasicBackupService implements BackupService {
     );
   }
 
+  @Override
+  public BackupDto findLatestBackupByStatus(BackupStatus status) {
+    return backupRepository.findTopByStatusOrderByEndedAtDesc(status)
+        .map(backupMapper::toDto)
+        .orElseThrow(() ->
+            new IllegalArgumentException("요청한 상태에 해당하는 백업이 존재하지 않습니다.")
+        );
+  }
+
 
   @Override
   public BackupDto runBackup(String requesterIp) {

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -109,6 +109,7 @@ public class BasicBackupService implements BackupService {
 
 
   @Override
+  @Transactional
   public BackupDto runBackup(String requesterIp) {
     if (!isBackupRequired()) {
       // 백업 필요 없으면 SKIPPED 처리
@@ -144,8 +145,7 @@ public class BasicBackupService implements BackupService {
     return inProgress;
   }
 
-  @Override
-  public boolean isBackupRequired() {
+  private boolean isBackupRequired() {
     Optional<Backup> lastCompletedBackup = backupRepository.findTopByStatusOrderByEndedAtDesc(
         BackupStatus.COMPLETED);
     if(lastCompletedBackup.isEmpty()){
@@ -159,8 +159,7 @@ public class BasicBackupService implements BackupService {
     return employeeChangeLogRepository.existsByUpdatedAtAfter(lastBackupTime);
   }
 
-  @Override
-  public BackupDto createInProgressBackup(String requesterIp) {
+  private BackupDto createInProgressBackup(String requesterIp) {
     Backup backup = Backup.builder()
         .worker(requesterIp)
         .status(BackupStatus.IN_PROGRESS)
@@ -171,8 +170,7 @@ public class BasicBackupService implements BackupService {
     return backupMapper.toDto(saved);
   }
 
-  @Override
-  public void markBackupCompleted(Long backupId, Long fileId) {
+  private void markBackupCompleted(Long backupId, Long fileId) {
     Backup backup = backupRepository.findById(backupId)
         .orElseThrow(() -> new EntityNotFoundException("백업을 찾을 수 없습니다."));
 
@@ -182,8 +180,7 @@ public class BasicBackupService implements BackupService {
     backup.completeBackup(file);
   }
 
-  @Override
-  public void markBackupFailed(Long backupId, Long logFileId) {
+  private void markBackupFailed(Long backupId, Long logFileId) {
     Backup backup = backupRepository.findById(backupId)
         .orElseThrow(() -> new EntityNotFoundException("백업을 찾을 수 없습니다."));
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/36-backup-api-> main

### 이슈 번호
- close #36 

### 변경 사항

- 백업 API (`BackupController`) 개발
  - GET `/api/backups`  
    - 커서 기반 페이징 및 필터링(작업자, 상태, 시작일 등) 지원하는 백업 목록 조회 API 구현
  - POST `/api/backups`  
    - 백업 실행 API 구현 (`runBackup` 호출)  
    - 요청자 IP 기반으로 작업 기록 생성 및 결과 응답
  - GET `/api/backups/latest`  
    - 상태별 최신 백업 1건 조회 API 구현 (`COMPLETED`, `FAILED` 등)


- 백업 서비스 (`BasicBackupService`) 개선
  - `runBackup(String requesterIp)`  
    - 반환 타입 `void` → `BackupDto`로 변경하여 API 응답 가능하도록 개선
  - `markBackupCompleted`, `markBackupFailed`, `createInProgressBackup` , 'isBackupRequired'
    - 외부 호출 불필요한 메서드는 `private`으로 접근 제어 변경 (캡슐화 강화)
  - `searchBackups()` 내 기본값 처리 제거  
    - `size` 기본값을 컨트롤러에서 `@RequestParam(defaultValue = "10")`으로 일원화
  - 트랜잭션 선언
    - 외부 호출 메서드에만 `@Transactional` 선언