### PR TITLE
[#34] 직원 API 구현 및 기존 코드 수정 작업

### DIFF
--- a/src/main/java/com/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank/controller/EmployeeController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -45,5 +46,11 @@ public class EmployeeController {
   @PostMapping
   public ResponseEntity<EmployeeDto> createEmployee(@RequestBody @Valid EmployeeCreateRequest request) {
     return ResponseEntity.ok(employeeService.create(request));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<EmployeeDto> deleteEmployee(@PathVariable Long id) {
+    EmployeeDto deletedEmployee = employeeService.delete(id);
+    return ResponseEntity.ok(deletedEmployee);
   }
 }

--- a/src/main/java/com/hrbank/exception/ErrorCode.java
+++ b/src/main/java/com/hrbank/exception/ErrorCode.java
@@ -9,7 +9,9 @@ public enum ErrorCode {
   DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부서를 찾을 수 없습니다."),
   PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
   EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "직원을 찾을 수 없습니다."),
-  EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다.");
+  EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
+  FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");
+
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hrbank/exception/ErrorCode.java
+++ b/src/main/java/com/hrbank/exception/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
 
   DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부서를 찾을 수 없습니다."),
   PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
-  EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "직원을 찾을 수 없습니다.");
+  EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "직원을 찾을 수 없습니다."),
+  EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hrbank/mapper/BinaryContentMapper.java
+++ b/src/main/java/com/hrbank/mapper/BinaryContentMapper.java
@@ -7,4 +7,5 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface BinaryContentMapper {
   BinaryContentDto toDto(BinaryContent binaryContent);
+  BinaryContent toEntity(BinaryContentDto dto);
 }

--- a/src/main/java/com/hrbank/mapper/EmployeeMapper.java
+++ b/src/main/java/com/hrbank/mapper/EmployeeMapper.java
@@ -10,6 +10,5 @@ import org.mapstruct.Mapping;
 public interface EmployeeMapper {
   @Mapping(source = "department.name", target = "departmentName")
   EmployeeDto toDto(Employee employee);
-
   List<EmployeeDto> toDtoList(List<Employee> employees);
 }

--- a/src/main/java/com/hrbank/service/BinaryContentService.java
+++ b/src/main/java/com/hrbank/service/BinaryContentService.java
@@ -9,4 +9,5 @@ public interface BinaryContentService {
 
   BinaryContentDto findById(Long id);
 
+  void delete(BinaryContent binaryContent);
 }

--- a/src/main/java/com/hrbank/service/BinaryContentService.java
+++ b/src/main/java/com/hrbank/service/BinaryContentService.java
@@ -9,5 +9,5 @@ public interface BinaryContentService {
 
   BinaryContentDto findById(Long id);
 
-  void delete(BinaryContent binaryContent);
+  void delete(Long id);
 }

--- a/src/main/java/com/hrbank/service/EmployeeService.java
+++ b/src/main/java/com/hrbank/service/EmployeeService.java
@@ -12,4 +12,6 @@ public interface EmployeeService {
   EmployeeDto update(Long id, EmployeeUpdateRequest request, String ip);
   
   EmployeeDto create(EmployeeCreateRequest request);
+
+  EmployeeDto delete(Long id);
 }

--- a/src/main/java/com/hrbank/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBinaryContentService.java
@@ -49,4 +49,9 @@ public class BasicBinaryContentService implements BinaryContentService {
     return binaryContentMapper.toDto(binaryContent);
   }
 
+  @Override
+  @Transactional
+  public void delete(BinaryContent binaryContent) {
+    binaryContentRepository.delete(binaryContent);
+  }
 }

--- a/src/main/java/com/hrbank/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBinaryContentService.java
@@ -3,10 +3,13 @@ package com.hrbank.service.basic;
 import com.hrbank.dto.binarycontent.BinaryContentCreateRequest;
 import com.hrbank.dto.binarycontent.BinaryContentDto;
 import com.hrbank.entity.BinaryContent;
+import com.hrbank.entity.Employee;
 import com.hrbank.mapper.BinaryContentMapper;
 import com.hrbank.exception.ErrorCode;
 import com.hrbank.exception.RestException;
+import com.hrbank.mapper.EmployeeMapper;
 import com.hrbank.repository.BinaryContentRepository;
+import com.hrbank.repository.EmployeeRepository;
 import com.hrbank.service.BinaryContentService;
 import com.hrbank.storage.BinaryContentStorage;
 import io.swagger.v3.oas.annotations.servers.Server;
@@ -23,6 +26,8 @@ public class BasicBinaryContentService implements BinaryContentService {
   private final BinaryContentRepository binaryContentRepository;
   private final BinaryContentStorage binaryContentStorage;
   private final BinaryContentMapper binaryContentMapper;
+  private final EmployeeRepository employeeRepository;
+  private final EmployeeMapper employeeMapper;
 
   @Override
   @Transactional
@@ -51,7 +56,19 @@ public class BasicBinaryContentService implements BinaryContentService {
 
   @Override
   @Transactional
-  public void delete(BinaryContent binaryContent) {
-    binaryContentRepository.delete(binaryContent);
+  public void delete(Long id) {
+    Employee employee = employeeRepository.findById(id)
+        .orElseThrow(() -> new RestException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
+
+    if (employee.getProfileImage() != null) {
+      try {
+        binaryContentStorage.deleteProfileImage(employee.getProfileImage().getId());
+      } catch (IOException e) {
+        throw new RestException(ErrorCode.FILE_DELETE_FAILED);
+      }
+    }
+
+    employeeRepository.delete(employee);
   }
 }
+

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
@@ -64,7 +64,7 @@ public class BasicEmployeeService implements EmployeeService {
 
         // 기존 프로필 이미지 삭제
         if (employee.getProfileImage() != null) {
-            binaryContentService.delete(employee.getProfileImage());
+            binaryContentService.delete(employee.getProfileImage().getId());
         }
     }
 
@@ -139,7 +139,7 @@ public class BasicEmployeeService implements EmployeeService {
         .orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
 
     if (employee.getProfileImage() != null) {
-      binaryContentService.delete(employee.getProfileImage());
+      binaryContentService.delete(employee.getProfileImage().getId());
     }
 
     employeeRepository.delete(employee);

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
@@ -124,4 +124,20 @@ public class BasicEmployeeService implements EmployeeService {
   private String generateEmployeeNumber() {
     return "E" + System.currentTimeMillis();
   }
+
+
+  @Override
+  @Transactional
+  public EmployeeDto delete(Long id) {
+    Employee employee = employeeRepository.findById(id)
+        .orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
+
+    if (employee.getProfileImage() != null) {
+      binaryContentService.delete(employee.getProfileImage());
+    }
+
+    employeeRepository.delete(employee);
+
+    return employeeMapper.toDto(employee);
+  }
 }

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
@@ -1,6 +1,7 @@
 package com.hrbank.service.basic;
 
 import com.hrbank.dto.binarycontent.BinaryContentCreateRequest;
+import com.hrbank.dto.binarycontent.BinaryContentDto;
 import com.hrbank.dto.employee.CursorPageResponseEmployeeDto;
 import com.hrbank.dto.employee.EmployeeCreateRequest;
 import com.hrbank.dto.employee.EmployeeDto;
@@ -12,10 +13,12 @@ import com.hrbank.entity.Employee;
 import com.hrbank.enums.EmployeeStatus;
 import com.hrbank.exception.ErrorCode;
 import com.hrbank.exception.RestException;
+import com.hrbank.mapper.BinaryContentMapper;
 import com.hrbank.mapper.EmployeeMapper;
 import com.hrbank.repository.DepartmentRepository;
 import com.hrbank.repository.EmployeeRepository;
 import com.hrbank.service.BinaryContentService;
+import com.hrbank.service.EmployeeChangeLogService;
 import com.hrbank.service.EmployeeService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,9 @@ public class BasicEmployeeService implements EmployeeService {
   private final DepartmentRepository departmentRepository;
   private final BinaryContentService binaryContentService;
   private final EmployeeMapper employeeMapper;
+  private final EmployeeChangeLogService changeLogService;
+  private final BinaryContentMapper binaryContentMapper;
+
 
   @Override
   public CursorPageResponseEmployeeDto searchEmployees(EmployeeSearchCondition condition) {
@@ -53,8 +59,8 @@ public class BasicEmployeeService implements EmployeeService {
 
     BinaryContent profileImage = null;
     if (request.profileImageId() != null) {
-        profileImage = binaryContentService.findById(request.profileImageId())
-            .orElseThrow(() -> new RestException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
+        BinaryContentDto profileImageDto = binaryContentService.findById(request.profileImageId());
+        profileImage = binaryContentMapper.toEntity(profileImageDto);
 
         // 기존 프로필 이미지 삭제
         if (employee.getProfileImage() != null) {

--- a/src/main/java/com/hrbank/storage/BinaryContentStorage.java
+++ b/src/main/java/com/hrbank/storage/BinaryContentStorage.java
@@ -112,4 +112,9 @@ public class BinaryContentStorage {
         .body(resource);
   }
 
+  // 프로필 이미지 삭제
+  public void deleteProfileImage(Long id) throws IOException {
+    Path target = root.resolve(id.toString());
+    Files.deleteIfExists(target);
+  }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/34-employee-delete

### 이슈 번호
- close #34 

### 변경 사항
- 직원 삭제 API: delete 메서드를 EmployeeService와 BasicEmployeeService에 추가하여, 직원 삭제 시 프로필 이미지도 삭제하도록 구현.
- update 메서드 수정: 이메일 중복 체크 및 기존 프로필 이미지 삭제 후 새 이미지로 변경.
- 타입 수정: BinaryContentDto 대신 BinaryContent를 사용하여 타입 오류 해결.
- 변경 전 상태 보존: changeLogService를 사용하여 직원 정보 변경 이력을 로그로 저장.

### 테스트 결과
