### PR TITLE
[#39] 백업 기능 에외 전역처리 및 Swagger 명세

### DIFF
--- a/src/main/java/com/hrbank/controller/BackupController.java
+++ b/src/main/java/com/hrbank/controller/BackupController.java
@@ -6,6 +6,7 @@ import com.hrbank.enums.BackupStatus;
 import com.hrbank.service.BackupService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -26,9 +27,9 @@ public class BackupController {
       @RequestParam(required = false) String worker,
       @RequestParam(required = false) BackupStatus status,
       @RequestParam(required = false)
-      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startedAtFrom,
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startedAtFrom,
       @RequestParam(required = false)
-      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startedAtTo,
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startedAtTo,
       @RequestParam(required = false) Long idAfter,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false, defaultValue = "10") Integer size,

--- a/src/main/java/com/hrbank/controller/BackupController.java
+++ b/src/main/java/com/hrbank/controller/BackupController.java
@@ -32,9 +32,9 @@ public class BackupController {
       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startedAtTo,
       @RequestParam(required = false) Long idAfter,
       @RequestParam(required = false) String cursor,
-      @RequestParam(required = false, defaultValue = "10") Integer size,
-      @RequestParam(required = false, defaultValue = "startedAt") String sortField,
-      @RequestParam(required = false, defaultValue = "DESC") String sortDirection
+      @RequestParam(defaultValue = "10") Integer size,
+      @RequestParam(defaultValue = "startedAt") String sortField,
+      @RequestParam(defaultValue = "DESC") String sortDirection
   ){
     CursorPageResponseBackupDto cursorPageResponseBackupDto = backupService.searchBackups(worker, status, startedAtFrom,startedAtTo,idAfter,cursor,size,sortField,sortDirection);
     return ResponseEntity.ok(cursorPageResponseBackupDto);

--- a/src/main/java/com/hrbank/controller/BackupController.java
+++ b/src/main/java/com/hrbank/controller/BackupController.java
@@ -1,11 +1,11 @@
 package com.hrbank.controller;
 
+import com.hrbank.controller.api.BackupApi;
 import com.hrbank.dto.backup.BackupDto;
 import com.hrbank.dto.backup.CursorPageResponseBackupDto;
 import com.hrbank.enums.BackupStatus;
 import com.hrbank.service.BackupService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -19,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/backups")
-public class BackupController {
+public class BackupController implements BackupApi {
   private final BackupService backupService;
 
+  @Override
   @GetMapping
   public ResponseEntity<CursorPageResponseBackupDto> getAllBackups(
       @RequestParam(required = false) String worker,
@@ -40,14 +41,16 @@ public class BackupController {
     return ResponseEntity.ok(cursorPageResponseBackupDto);
   }
 
+  @Override
   @PostMapping
   public ResponseEntity<BackupDto> createBackup(HttpServletRequest servletRequest){
       BackupDto backupDto = backupService.runBackup(servletRequest.getRemoteAddr());
       return ResponseEntity.ok(backupDto);
   }
 
+  @Override
   @GetMapping(value = "/latest")
-  public ResponseEntity<BackupDto> getLatestBackup(@RequestParam(required = false, defaultValue = "COMPLETED") BackupStatus status){
+  public ResponseEntity<BackupDto> getLatestBackup(@RequestParam( defaultValue = "COMPLETED") BackupStatus status){
     BackupDto backupDto = backupService.findLatestBackupByStatus(status);
     return ResponseEntity.ok(backupDto);
   }

--- a/src/main/java/com/hrbank/controller/api/BackupApi.java
+++ b/src/main/java/com/hrbank/controller/api/BackupApi.java
@@ -1,0 +1,91 @@
+package com.hrbank.controller.api;
+
+import com.hrbank.dto.backup.BackupDto;
+import com.hrbank.dto.backup.CursorPageResponseBackupDto;
+import com.hrbank.dto.error.ErrorResponse;
+import com.hrbank.enums.BackupStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+public interface BackupApi {
+
+  @Operation(summary = "백업 실행")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "백업 정상 실행"),
+      @ApiResponse(responseCode = "409", description = "이미 진행 중인 백업이 있음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<BackupDto> createBackup(HttpServletRequest servletRequest);
+
+  @Operation(summary = "백업 목록 조회")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "정상 조회"),
+      @ApiResponse(responseCode = "404", description = "백업을 찾을 수 없습니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<CursorPageResponseBackupDto> getAllBackups(
+      @Parameter(description = "백업 작업자 IP 또는 이름")
+      String worker,
+
+      @Parameter(description = "백업 상태")
+      BackupStatus status,
+
+      @Parameter(description = "백업 시작 시간 이후", example = "2025-04-20T00:00:00")
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+      LocalDateTime startedAtFrom,
+
+      @Parameter(description = "백업 시작 시간 이전", example = "2025-04-22T23:59:59")
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+      LocalDateTime startedAtTo,
+
+      @Parameter(description = "마지막으로 조회된 ID 이후의 데이터")
+      Long idAfter,
+
+      @Parameter(description = "다음 페이지 조회를 위한 커서")
+      String cursor,
+
+      @Parameter(
+          description = "페이지 크기",
+          example = "10",
+          schema = @Schema(defaultValue = "10")
+      )
+      Integer size,
+
+      @Parameter(
+          description = "정렬 필드 (startedAt, endedAt)",
+          example = "startedAt",
+          schema = @Schema(defaultValue = "startedAt")
+      )
+      String sortField,
+
+      @Parameter(
+          description = "정렬 방향 (ASC, DESC)",
+          example = "DESC",
+          schema = @Schema(defaultValue = "DESC")
+      )
+      String sortDirection
+  );
+
+  @Operation(summary = "최신 백업 조회")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "정상 조회"),
+      @ApiResponse(responseCode = "404", description = "요청한 상태에 해당하는 백업이 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  ResponseEntity<BackupDto> getLatestBackup(
+      @Parameter(
+          description = "조회할 백업 상태",
+          schema = @Schema(defaultValue = "COMPLETED")
+      )
+      BackupStatus status
+  );
+}

--- a/src/main/java/com/hrbank/dto/backup/BackupDto.java
+++ b/src/main/java/com/hrbank/dto/backup/BackupDto.java
@@ -2,13 +2,14 @@ package com.hrbank.dto.backup;
 
 import com.hrbank.enums.BackupStatus;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record BackupDto(
     Long id,
     String worker,
-    Instant startedAt,
-    Instant endedAt,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
     BackupStatus status,
     Long fileId
 ) {

--- a/src/main/java/com/hrbank/entity/Backup.java
+++ b/src/main/java/com/hrbank/entity/Backup.java
@@ -5,16 +5,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.Instant;;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 
 @Entity
@@ -34,10 +32,10 @@ public class Backup {
   private String worker;
 
   @Column(name = "started_at", nullable = false)
-  private Instant startedAt;
+  private LocalDateTime startedAt;
 
   @Column(name = "ended_at", nullable = false)
-  private Instant endedAt;
+  private LocalDateTime endedAt;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
@@ -49,13 +47,13 @@ public class Backup {
 
   public void completeBackup(BinaryContent file) {
     this.status = BackupStatus.COMPLETED;
-    this.endedAt = Instant.now();
+    this.endedAt = LocalDateTime.now();
     this.file = file;
   }
 
   public void failBackup(BinaryContent logFile) {
     this.status = BackupStatus.FAILED;
-    this.endedAt = Instant.now();
+    this.endedAt = LocalDateTime.now();
     this.file = logFile;
   }
 

--- a/src/main/java/com/hrbank/exception/ErrorCode.java
+++ b/src/main/java/com/hrbank/exception/ErrorCode.java
@@ -8,7 +8,14 @@ public enum ErrorCode {
 
   DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부서를 찾을 수 없습니다."),
   PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
-  EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "직원을 찾을 수 없습니다.");
+  EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "직원을 찾을 수 없습니다."),
+
+  // BACKUP
+  BACKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "백업을 찾을 수 없습니다."),
+  BACKUP_LATEST_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 상태에 해당하는 백업이 존재하지 않습니다."),
+  BACKUP_CSV_NOT_FOUND(HttpStatus.NOT_FOUND, "백업 CSV 파일을 찾을 수 없습니다."),
+  BACKUP_ERROR_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "백업 에러 로그 파일을 찾을 수 없습니다."),
+  BACKUP_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 진행 중인 백업이 있습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/hrbank/repository/BackupRepository.java
+++ b/src/main/java/com/hrbank/repository/BackupRepository.java
@@ -12,5 +12,6 @@ public interface BackupRepository extends JpaRepository<Backup, Long> {
   //가장 최근에 status한 백업 조회
   Optional<Backup> findTopByStatusOrderByEndedAtDesc(BackupStatus status);
 
+  boolean existsByStatus(BackupStatus status);
 
 }

--- a/src/main/java/com/hrbank/service/BackupService.java
+++ b/src/main/java/com/hrbank/service/BackupService.java
@@ -4,11 +4,12 @@ import com.hrbank.dto.backup.BackupDto;
 import com.hrbank.dto.backup.CursorPageResponseBackupDto;
 import com.hrbank.enums.BackupStatus;
 import java.time.Instant;
+import java.time.LocalDateTime;
 
 public interface BackupService {
 
   // 조건에 맞는 백업 목록 조회
-  CursorPageResponseBackupDto searchBackups(String worker, BackupStatus status, Instant from, Instant to, Long id, String cursor, Integer size, String sortField, String sortDirection);
+  CursorPageResponseBackupDto searchBackups(String worker, BackupStatus status, LocalDateTime from, LocalDateTime to, Long id, String cursor, Integer size, String sortField, String sortDirection);
 
   // status한 가장 최근 백업 조회
   BackupDto findLatestBackupByStatus(BackupStatus status);

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
@@ -49,7 +50,7 @@ public class BasicBackupService implements BackupService {
 
   @Override
   public CursorPageResponseBackupDto searchBackups(
-      String worker, BackupStatus status, Instant from, Instant to,
+      String worker, BackupStatus status, LocalDateTime from, LocalDateTime to,
       Long id, String cursor, Integer size, String sortField, String sortDirection) {
 
     // 필터링
@@ -124,8 +125,8 @@ public class BasicBackupService implements BackupService {
       Backup skipped = Backup.builder()
           .worker(requesterIp)
           .status(BackupStatus.SKIPPED)
-          .startedAt(Instant.now())
-          .endedAt(Instant.now())
+          .startedAt(LocalDateTime.now())
+          .endedAt(LocalDateTime.now())
           .build();
       backupRepository.save(skipped);
       return backupMapper.toDto(skipped);
@@ -160,18 +161,18 @@ public class BasicBackupService implements BackupService {
       return true;
     }
 
-    Instant lastBackupTime = lastCompletedBackup.get().getEndedAt();
+    LocalDateTime lastBackupTime = lastCompletedBackup.get().getEndedAt();
 
     // 특정 시간 이후 직원 업데이트 내역 확인
     // 추후 구현 필요
-    return employeeChangeLogRepository.existsByUpdatedAtAfter(lastBackupTime);
+    return employeeChangeLogRepository.existsByAtAfter(lastBackupTime);
   }
 
   private BackupDto createInProgressBackup(String requesterIp) {
     Backup backup = Backup.builder()
         .worker(requesterIp)
         .status(BackupStatus.IN_PROGRESS)
-        .startedAt(Instant.now())
+        .startedAt(LocalDateTime.now())
         .build();
 
     Backup saved = backupRepository.save(backup);

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -120,6 +120,12 @@ public class BasicBackupService implements BackupService {
   @Override
   @Transactional
   public BackupDto runBackup(String requesterIp) {
+
+    // 실행중인 백업 유무 확인
+    if (backupRepository.existsByStatus(BackupStatus.IN_PROGRESS)) {
+      throw new RestException(ErrorCode.BACKUP_ALREADY_IN_PROGRESS);
+    }
+
     if (!isBackupRequired()) {
       // 백업 필요 없으면 SKIPPED 처리
       Backup skipped = Backup.builder()


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/39-backup-exception-handler-> main

### 이슈 번호
- close #39 

### 변경 사항

- **refactor: Instant → LocalDateTime으로 시간 타입 변경**
  - API 요청 및 서비스 로직에서 `Instant` 대신 `LocalDateTime` 사용
  - 시간대 의존성 제거 및 Swagger 문서에 ISO 포맷 적용

- **refactor: @RequestParam에서 중복된 required 속성 제거**
  - `defaultValue`가 지정된 파라미터에 `required = false` 제거하여 코드 간결화

- **feat: 백업 진행 중 상태 감지 시 409 Conflict 에러 처리 추가**
  - `IN_PROGRESS` 상태의 백업이 존재할 경우 409 에러 반환
  - 중복 실행 방지를 위한 예외 처리 추가

- **feat: 백업 도메인 에러 코드 정의 및 서비스 로직 적용**
  - ErrorCode 항목 추가:
    - `BACKUP_NOT_FOUND`
    - `BACKUP_LATEST_NOT_FOUND`
    - `BACKUP_CSV_NOT_FOUND`
    - `BACKUP_ERROR_LOG_NOT_FOUND`
    - `BACKUP_ALREADY_IN_PROGRESS`
  - 각 상황에 맞는 예외를 서비스 내에 적용

- **docs: Swagger 문서용 BackupApi 인터페이스 정리*
  - Swagger 문서 전용 `BackupApi` 인터페이스 분리
  - `@Parameter` + `@Schema(defaultValue = "...")` 조합으로 문서 명확화