### PR TITLE
[#34] BasicBinaryContentService delete 책임분리 재설정

### DIFF
--- a/src/main/java/com/hrbank/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBinaryContentService.java
@@ -59,18 +59,11 @@ public class BasicBinaryContentService implements BinaryContentService {
   @Override
   @Transactional
   public void delete(Long id) {
-    Employee employee = employeeRepository.findById(id)
-        .orElseThrow(() -> new RestException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
-
-    if (employee.getProfileImage() != null) {
-      try {
-        binaryContentStorage.deleteProfileImage(employee.getProfileImage().getId());
-      } catch (IOException e) {
-        throw new RestException(ErrorCode.FILE_DELETE_FAILED);
-      }
+    if (!binaryContentRepository.existsById(id)) {
+      throw new RestException(ErrorCode.PROFILE_IMAGE_NOT_FOUND);
     }
-
-    employeeRepository.delete(employee);
+    binaryContentStorage.delete(id);
+    binaryContentRepository.deleteById(id);
   }
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) 34-employee-delete-fix -> main

### 이슈 번호
- close #34 

### 변경 사항
- BinaryContent 객체에만 집중하여 삭제 처리 (책임분리)
- 데이터베이스에서 삭제

리뷰 확인 받았고 바로 머지하도록 하겠습니다.
