### PR TITLE
[#100] PostgreSQL ENUM 타입 호환을 위한 cb.literal 적용

### DIFF
--- a/src/main/java/com/hrbank/repository/specification/EmployeeChangeLogSpecification.java
+++ b/src/main/java/com/hrbank/repository/specification/EmployeeChangeLogSpecification.java
@@ -31,7 +31,7 @@ public class EmployeeChangeLogSpecification {
 
   public static Specification<EmployeeChangeLog> typeEquals(EmployeeChangeLogType type) {
     return (root, query, cb) ->
-        type == null ? null : cb.equal(root.get("type"), type);
+        type == null ? null : cb.equal(root.get("type"), cb.literal(type));  // enum 타입으로 처리할 수 있도록
   }
 
   public static Specification<EmployeeChangeLog> atBetween(LocalDateTime start, LocalDateTime end) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/100-specification-enum-fix -> main

### 이슈 번호
- close #100

### 변경 사항
- `EmployeeChangeLogSpecification.typeEquals` 메서드 내 enum 비교 조건을 `cb.equal(root.get("type"), cb.literal(type))` 방식으로 수정하였습니다.
- PostgreSQL에서는 enum과 문자열 간 비교가 허용되지 않아, 이전 코드(`cb.equal(root.get("type"), type)`)로는 실행 오류가 발생했습니다.
