### PR TITLE
[#98] 백업 필요성 판단 로직 개선 및 최신 백업 조회 방식 수정

### DIFF
--- a/src/main/java/com/hrbank/entity/Backup.java
+++ b/src/main/java/com/hrbank/entity/Backup.java
@@ -35,7 +35,7 @@ public class Backup {
   @Column(name = "started_at", nullable = false)
   private LocalDateTime startedAt;
 
-  @Column(name = "ended_at", nullable = false)
+  @Column(name = "ended_at")
   private LocalDateTime endedAt;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/hrbank/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank/repository/EmployeeRepository.java
@@ -47,4 +47,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>, Emplo
           "WHERE (:status IS NULL OR e.status = :status) GROUP BY e.position")
   List<Object[]> countByPositionAndStatus(@Param("status") EmployeeStatus status);
 
+  boolean existsBy();
+
 }

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -60,7 +60,7 @@ public class BasicBackupService implements BackupService {
         .filter(backup -> status == null || backup.getStatus() == status)
         .filter(backup -> from == null || backup.getStartedAt().isAfter(from))
         .filter(backup -> to == null || backup.getStartedAt().isBefore(to))
-        . collect(Collectors.toList());
+        .collect(Collectors.toList());
 
     // 정렬 기준 설정
     Comparator<Backup> comparator = "endedAt".equalsIgnoreCase(sortField)

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -57,7 +58,7 @@ public class BasicBackupService implements BackupService {
         .filter(backup -> status == null || backup.getStatus() == status)
         .filter(backup -> from == null || backup.getStartedAt().isAfter(from))
         .filter(backup -> to == null || backup.getStartedAt().isBefore(to))
-        .toList();
+        . collect(Collectors.toList());
 
     // 정렬 기준 설정
     Comparator<Backup> comparator = "endedAt".equalsIgnoreCase(sortField)

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -112,9 +112,7 @@ public class BasicBackupService implements BackupService {
   public BackupDto findLatestBackupByStatus(BackupStatus status) {
     return backupRepository.findTopByStatusOrderByEndedAtDesc(status)
         .map(backupMapper::toDto)
-        .orElseThrow(() ->
-            new RestException(ErrorCode.BACKUP_LATEST_NOT_FOUND)
-        );
+        .orElse(null);
   }
 
 

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -14,6 +14,7 @@ import com.hrbank.mapper.BackupMapper;
 import com.hrbank.repository.BackupRepository;
 import com.hrbank.repository.BinaryContentRepository;
 import com.hrbank.repository.EmployeeChangeLogRepository;
+import com.hrbank.repository.EmployeeRepository;
 import com.hrbank.service.BackupService;
 import com.hrbank.storage.BinaryContentStorage;
 import java.io.File;
@@ -43,6 +44,7 @@ public class BasicBackupService implements BackupService {
   private final BackupRepository backupRepository;
   private final BackupMapper backupMapper;
   private final EmployeeChangeLogRepository employeeChangeLogRepository;
+  private final EmployeeRepository employeeRepository;
   private final BinaryContentRepository binaryContentRepository;
   private final BinaryContentStorage binaryContentStorage;
   private final EmployeeCsvGenerator employeeCsvGenerator;
@@ -159,8 +161,14 @@ public class BasicBackupService implements BackupService {
   }
 
   private boolean isBackupRequired() {
+    // 직원이 없으면 백업할 필요 X
+    if(!employeeRepository.existsBy()){
+      return false;
+    }
+
     Optional<Backup> lastCompletedBackup = backupRepository.findTopByStatusOrderByEndedAtDesc(
         BackupStatus.COMPLETED);
+
     if(lastCompletedBackup.isEmpty()){
       return true;
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/98-immutablelist-collect) -> main

### 이슈 번호
- close #98 

### 변경 사항
- stream().toList() 사용 시 ImmutableList가 생성되어 sort() 호출 시 UnsupportedOperationException이 발생하던 문제를 수정했습니다.
- toList() 대신 collect(Collectors.toList())를 사용하여 변경 가능한 리스트를 생성하고, 정상적으로 정렬이 가능하도록 수정했습니다.
- employeeRepository에 existsBy 메서드를 추가하여 직원 데이터가 하나도 없을 경우 백업을 수행하지 않도록 로직을 수정했습니다.
- 최초 백업 시에도 직원 데이터 존재 여부를 먼저 확인하여 불필요한 백업을 방지했습니다.
- findTopByStatusOrderByEndedAtDesc 호출 시, 백업 데이터가 없을 경우 예외를 던지지 않고 null을 반환하도록 수정했습니다.

