### PR TITLE
[#103] 기존 직원 수 조회 DB 호환 불가한 문법 변경 및 controller단 수정

### DIFF
--- a/src/main/java/com/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank/controller/EmployeeController.java
@@ -61,7 +61,7 @@ public class EmployeeController {
   @PostMapping
   public ResponseEntity<EmployeeDto> createEmployee(
       @RequestPart("employee") @Valid EmployeeCreateRequest request,
-      @RequestPart("profile") MultipartFile profileImage, HttpServletRequest httpRequest) {
+      @RequestPart(value = "profile", required = false) MultipartFile profileImage, HttpServletRequest httpRequest) {
     String ip = httpRequest.getRemoteAddr();
     return ResponseEntity.ok(employeeService.create(request, profileImage, ip));
   }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/103-EmployeeBugResolve -> main

### 이슈 번호
- close #103 

### 변경 사항
- 기존에 직원 수 조회 FORMATDATETIME 함수가 postgreSQL에는 호환이 불가하여 대시보드 접속 시 오류 코드 발생하여 날짜 포맷팅 함수 변경했습니다.
- 컨트롤러단에 직원 생성시 프로필 이미지 등록없이도 생성 가능하도록 컨트롤러 수정했습니다.

