### PR TITLE
[#120] 직원 수 추이 조회 API 파라미터 방식 변경 및 리턴 타입 수정

### DIFF
--- a/src/main/java/com/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank/controller/EmployeeController.java
@@ -14,8 +14,6 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
@@ -93,8 +91,12 @@ public class EmployeeController {
 
   @Operation(summary = "직원 수 추이 조회")
   @GetMapping("/stats/trend")
-  public Page<EmployeeTrendDto> getEmployeeTrends(EmployeeSearchCondition condition, Pageable pageable) {
-    return employeeService.findEmployeeTrends(condition, pageable);
+  public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrends(
+      @RequestParam(value = "from", required = false) LocalDate from,
+      @RequestParam(value = "to", required = false) LocalDate to,
+      @RequestParam(value = "unit", defaultValue = "month") String unit
+      ) {
+    return ResponseEntity.ok(employeeService.findEmployeeTrends(from, to, unit));
   }
 
   @GetMapping("/stats/distribution")

--- a/src/main/java/com/hrbank/dto/employee/EmployeeTrendDto.java
+++ b/src/main/java/com/hrbank/dto/employee/EmployeeTrendDto.java
@@ -1,15 +1,20 @@
 package com.hrbank.dto.employee;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class EmployeeTrendDto {
-  private String data;
+  private String date;
   private Long count;
   private Long change;
   private Double changeRate;
+
+  public EmployeeTrendDto(String date, Long count) {
+    this.date = date;
+    this.count = count;
+    this.change = 0L;
+    this.changeRate = 0.0;
+  }
 }

--- a/src/main/java/com/hrbank/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank/repository/EmployeeRepository.java
@@ -13,7 +13,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface EmployeeRepository extends JpaRepository<Employee, Long>, EmployeeRepositoryCustom {
+public interface EmployeeRepository extends JpaRepository<Employee, Long>,
+    EmployeeRepositoryCustom {
   Optional<Employee> findByEmail(String email);
 
   // EmployeeCsvGenerator에서 사용하는 메서드
@@ -26,7 +27,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>, Emplo
   )
   List<Employee> findNextChunk(@Param("lastId") Long lastId, Pageable pageable);
 
-  Page<EmployeeTrendDto> findEmployeeTrends(EmployeeSearchCondition condition, Pageable pageable);
+  List<EmployeeTrendDto> findEmployeeTrends(LocalDate from, LocalDate to, String unit);
 
   Page<Employee> findAllWithFilter(EmployeeSearchCondition condition, Pageable pageable);
   @Query("SELECT COUNT(e) FROM Employee e " +

--- a/src/main/java/com/hrbank/repository/EmployeeRepositoryCustom.java
+++ b/src/main/java/com/hrbank/repository/EmployeeRepositoryCustom.java
@@ -3,10 +3,12 @@ package com.hrbank.repository;
 import com.hrbank.dto.employee.EmployeeSearchCondition;
 import com.hrbank.dto.employee.EmployeeTrendDto;
 import com.hrbank.entity.Employee;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface EmployeeRepositoryCustom {
   Page<Employee> findAllWithFilter(EmployeeSearchCondition condition, Pageable pageable);
-  Page<EmployeeTrendDto> findEmployeeTrends(EmployeeSearchCondition condition, Pageable pageable);
+  List<EmployeeTrendDto> findEmployeeTrends(LocalDate from, LocalDate to, String unit);
 }

--- a/src/main/java/com/hrbank/service/EmployeeService.java
+++ b/src/main/java/com/hrbank/service/EmployeeService.java
@@ -5,13 +5,11 @@ import com.hrbank.dto.employee.EmployeeCreateRequest;
 import com.hrbank.dto.employee.EmployeeDistributionDto;
 import com.hrbank.dto.employee.EmployeeDto;
 import com.hrbank.dto.employee.EmployeeSearchCondition;
+import com.hrbank.dto.employee.EmployeeTrendDto;
 import com.hrbank.dto.employee.EmployeeUpdateRequest;
 import java.time.LocalDate;
-import com.hrbank.dto.employee.EmployeeTrendDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface EmployeeService {
   CursorPageResponseEmployeeDto searchEmployees(EmployeeSearchCondition condition);
@@ -24,7 +22,7 @@ public interface EmployeeService {
 
   EmployeeDto findById(Long id);
 
-  Page<EmployeeTrendDto> findEmployeeTrends(EmployeeSearchCondition condition, Pageable pageable);
+  List<EmployeeTrendDto> findEmployeeTrends(LocalDate from, LocalDate to, String unit);
 
   long getEmployeeCount(String status, LocalDate fromDate, LocalDate toDate);
 

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
@@ -177,9 +177,8 @@ public class BasicEmployeeService implements EmployeeService {
   }
 
   @Override
-  public Page<EmployeeTrendDto> findEmployeeTrends(EmployeeSearchCondition condition,
-      Pageable pageable) {
-    return employeeRepository.findEmployeeTrends(condition, pageable);
+  public List<EmployeeTrendDto> findEmployeeTrends(LocalDate from, LocalDate to, String unit) {
+    return employeeRepository.findEmployeeTrends(from, to, unit);
   }
 
   @Override


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/120-employee-trend -> main

### 이슈 번호
- close #120 

### 변경 사항
- 직원 수 추이 조회 API (`/api/employees/stats/trend`)의 입력 파라미터를 변경했습니다.
  - `EmployeeSearchCondition` + `Pageable` → `@RequestParam` 방식(`from`, `to`, `unit`)으로 수정
- 기본 반환 타입을 `Page<EmployeeTrendDto>` → `List<EmployeeTrendDto>`로 변경했습니다.
- 서비스 로직(`findEmployeeTrends`)에서 Pageable 관련 로직 제거하고, List만 반환하도록 수정했습니다.
- JPQL 쿼리문에서 H2 데이터베이스 호환을 위해 `FORMATDATETIME` 대신 `TO_CHAR` 함수 사용하도록 수정했습니다.