### PR TITLE
[직원수정이력] 직원 생성/삭제 일 때도 상세 내역 저장

### DIFF
--- a/src/main/java/com/hrbank/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank/repository/EmployeeRepository.java
@@ -55,7 +55,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
   boolean existsBy();
 
   @Query("select e from Employee e "
-      + "join fetch e.department d join fetch e.profileImage p "
+      + "join fetch e.department d left join fetch e.profileImage p "
       + "where e.id = :id")
   Optional<Employee> findByIdWithDepartmentAndBinaryContent(@Param("id") Long id);
 }

--- a/src/main/java/com/hrbank/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank/repository/EmployeeRepository.java
@@ -54,6 +54,8 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
 
   boolean existsBy();
 
-  @Query("select e from Employee e join fetch e.department d where e.id = :id")
-  Optional<Employee> findByIdWithDepartment(@Param("id") Long id);
+  @Query("select e from Employee e "
+      + "join fetch e.department d join fetch e.profileImage p "
+      + "where e.id = :id")
+  Optional<Employee> findByIdWithDepartmentAndBinaryContent(@Param("id") Long id);
 }

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {
@@ -71,24 +73,44 @@ public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {
         ipAddress,
         LocalDateTime.now()
     );
+    // 모든 type의 detail 생성
+    if(type == EmployeeChangeLogType.CREATED) {
+      addDetailIfChanged(changeLog, "hireDate", null, after.getHireDate().toString());
+      addDetailIfChanged(changeLog, "name", null, after.getName());
+      addDetailIfChanged(changeLog, "position", null, after.getPosition());
+      addDetailIfChanged(changeLog, "department", null, after.getDepartment().getName());
+      addDetailIfChanged(changeLog, "email", null, after.getEmail());
+      addDetailIfChanged(changeLog, "employeeNumber", null, after.getEmployeeNumber());
+      addDetailIfChanged(changeLog, "status", null, after.getStatus().name());
+      addDetailIfChanged(changeLog, "profileImage", null,
+          Optional.ofNullable(after.getProfileImage()).map(BinaryContent::getFileName).orElse(null));
+    }
 
-    // 3. UPDATED일 경우에만 필드 비교 후 detail 생성
-    if (type == EmployeeChangeLogType.UPDATED && before != null && after != null) {
-
+    else if (type == EmployeeChangeLogType.UPDATED && before != null && after != null) {
+      addDetailIfChanged(changeLog, "hireDate"
+          , before.getHireDate().toString(), after.getHireDate().toString());
       addDetailIfChanged(changeLog, "name", before.getName(), after.getName());
-      addDetailIfChanged(changeLog, "email", before.getEmail(), after.getEmail());
       addDetailIfChanged(changeLog, "position", before.getPosition(), after.getPosition());
-      addDetailIfChanged(changeLog, "status", before.getStatus().name(), after.getStatus().name());
-
       // 부서는 null 가능성 있음
       addDetailIfChanged(changeLog, "department",
           Optional.ofNullable(before.getDepartment()).map(Department::getName).orElse(null),
           Optional.ofNullable(after.getDepartment()).map(Department::getName).orElse(null));
-
+      addDetailIfChanged(changeLog, "email", before.getEmail(), after.getEmail());
+      addDetailIfChanged(changeLog, "status", before.getStatus().name(), after.getStatus().name());
       // 프로필 이미지는 null 가능성 있음
       addDetailIfChanged(changeLog, "profileImage",
           Optional.ofNullable(before.getProfileImage()).map(BinaryContent::getFileName).orElse(null),
           Optional.ofNullable(after.getProfileImage()).map(BinaryContent::getFileName).orElse(null));
+    }
+    else{
+      addDetailIfChanged(changeLog, "hireDate", before.getHireDate().toString(), null);
+      addDetailIfChanged(changeLog, "name", before.getName(), null);
+      addDetailIfChanged(changeLog, "position", before.getPosition(), null);
+      addDetailIfChanged(changeLog, "department", before.getDepartment().getName(), null);
+      addDetailIfChanged(changeLog, "email", before.getEmail(), null);
+      addDetailIfChanged(changeLog, "status", before.getStatus().name(), null);
+      addDetailIfChanged(changeLog, "profileImage",
+          Optional.ofNullable(before.getProfileImage()).map(BinaryContent::getFileName).orElse(null), null);
     }
 
     // 4. 저장

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,7 +29,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
@@ -27,7 +27,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,7 +85,7 @@ public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {
           Optional.ofNullable(after.getProfileImage()).map(BinaryContent::getFileName).orElse(null));
     }
 
-    else if (type == EmployeeChangeLogType.UPDATED && before != null && after != null) {
+    else if (type == EmployeeChangeLogType.UPDATED) {
       addDetailIfChanged(changeLog, "hireDate"
           , before.getHireDate().toString(), after.getHireDate().toString());
       addDetailIfChanged(changeLog, "name", before.getName(), after.getName());

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeService.java
@@ -72,7 +72,7 @@ public class BasicEmployeeService implements EmployeeService {
   public EmployeeDto update(
       Long id, EmployeeUpdateRequest request, BinaryContentCreateRequest fileRequest, String ip
   ) {
-    Employee employee = employeeRepository.findById(id)
+    Employee employee = employeeRepository.findByIdWithDepartmentAndBinaryContent(id)
         .orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
     String newEmail = request.email();
 
@@ -163,8 +163,12 @@ public class BasicEmployeeService implements EmployeeService {
   @Override
   @Transactional
   public void delete(Long id, String ip) {
-    Employee employee = employeeRepository.findById(id).orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
-    Employee before = new Employee(employee.getName(), employee.getEmail(), employee.getEmployeeNumber(), employee.getDepartment(), employee.getPosition(), employee.getHireDate(), employee.getStatus());
+    Employee employee = employeeRepository.findByIdWithDepartmentAndBinaryContent(id)
+        .orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
+    Employee before = new Employee(
+        employee.getName(), employee.getEmail(), employee.getEmployeeNumber(),
+        employee.getDepartment(), employee.getPosition(), employee.getHireDate(), employee.getStatus());
+    before.changeProfileImage(employee.getProfileImage());
 
     if (employee.getProfileImage() != null) {
       binaryContentService.delete(employee.getProfileImage().getId());
@@ -176,7 +180,7 @@ public class BasicEmployeeService implements EmployeeService {
 
   @Override
   public EmployeeDto findById(Long id) {
-    Employee employee = employeeRepository.findByIdWithDepartment(id)
+    Employee employee = employeeRepository.findByIdWithDepartmentAndBinaryContent(id)
         .orElseThrow(() -> new RestException(ErrorCode.EMPLOYEE_NOT_FOUND));
     return employeeMapper.toDto(employee);
   }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/bug-> main

### 이슈 번호
- close 

### 변경 사항
<직원 관리>
- 생성/수정/삭제 시 수정 이력 저장때문에 항상 부서의 이름, 이미지의 파일이름을 가져와야 함 => N+1문제가 있을 수 있기에, N+1문제를 방지하고자 fetch join을 사용해 Department 데이터와 BinaryContent 데이터를 힌 번에 가져옴. 
- 직원 삭제 시 before(직원 객체)에 BinaryContent객체를 안 넣어주기에 바꿈. 

<직원 수정 이력 관리 - saveChangeLog()>
- 기존엔 직원을 수정하였을 때만 상세 이력을 저장하였음. 하지만 프로토타입을 보니, 생성/삭제일 때도 저장이 되기에 이를 추가해줌.
   - 삭제일 땐, 사번을 보여주지 않기에, 삭제일 경우 사번은 제외시켜주었음.
   - 수정 - 상세 이력 순서를 프로토타입과 동일하게 변경 & 입사일 이력 저장되도록 추가

### 테스트 결과
- 직원이 생성될 경우

<img width="617" alt="변경_후_생성" src="https://github.com/user-attachments/assets/345b80b0-54d7-461d-a721-23e61072e01c" />

- 삭제될 경우

<img width="505" alt="변경_후_삭제" src="https://github.com/user-attachments/assets/a03ea80c-8131-41aa-866e-6cf0e863bb38" />
