### PR TITLE
[#135] backup 파일 이름 변경

### DIFF
--- a/src/main/java/com/hrbank/generator/EmployeeCsvGenerator.java
+++ b/src/main/java/com/hrbank/generator/EmployeeCsvGenerator.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +29,11 @@ public class EmployeeCsvGenerator {
       propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ, readOnly = true
   )
   public File generate(BackupDto dto) throws IOException {
-    DateTimeFormatter fmt = DateTimeFormatter
-        .ofPattern("yyyyMMdd_HHmmss")
-        .withZone(ZoneId.of("Asia/Seoul"));
+    // 혹시 모르니 임시 파일도 유니크한 파일명으로 저장되도록 함.
+    DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
     String timestamp = fmt.format(dto.startedAt());
     String backupId = String.valueOf(dto.id());
-
-    File tempFile = File.createTempFile(
-        "employee_backup_" + backupId + "_" + timestamp,".csv");
+    File tempFile = File.createTempFile(backupId + "_" + timestamp,".csv");
 
     tempFile.deleteOnExit(); // JVM 종료 시 임시 파일 삭제(이중 대책)
 

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -151,7 +151,7 @@ public class BasicBackupService implements BackupService {
 
     } catch (Exception e) {
       // 로그 파일 생성
-      Long logFileId = saveErrorLogFile(inProgress.id(), e);
+      Long logFileId = saveErrorLogFile(inProgress, e);
 
       // 실패 처리
       markBackupFailed(inProgress.id(), logFileId);
@@ -270,13 +270,18 @@ public class BasicBackupService implements BackupService {
     }
   }
 
-  private Long saveErrorLogFile(Long backupId, Exception e) {
+  private Long saveErrorLogFile(BackupDto dto, Exception e) {
     StringWriter sw = new StringWriter();
     e.printStackTrace(new PrintWriter(sw));
     String trace = sw.toString();
 
     BinaryContent binaryContent = new BinaryContent();
-    binaryContent.setFileName("backup_error_" + backupId + ".log");
+    DateTimeFormatter fmt = DateTimeFormatter
+        .ofPattern("yyyyMMdd_HHmmss");
+    String timestamp = fmt.format(dto.startedAt());
+    String backupId = String.valueOf(dto.id());
+
+    binaryContent.setFileName("backup_error_" + backupId + "_" + timestamp + ".log");
     binaryContent.setContentType("text/plain");
     binaryContent = binaryContentRepository.save(binaryContent);
     Long contentId = binaryContent.getId();

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -24,6 +24,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -239,8 +240,14 @@ public class BasicBackupService implements BackupService {
     try{
       tempCsv = employeeCsvGenerator.generate(dto);
       binaryContentStorage.putCsvFile(contentId, tempCsv);
+      // 임시 파일 생성때의 이름을 쓰면 불필요한 랜덤값이 붙으니, 자체적으로 파일이름 생성.
+      DateTimeFormatter fmt = DateTimeFormatter
+          .ofPattern("yyyyMMdd_HHmmss");
+      String timestamp = fmt.format(dto.startedAt());
+      String backupId = String.valueOf(dto.id());
+      String fileName = "employee_backup_" + backupId + "_" + timestamp + ".csv";
 
-      binaryContent.setFileName(tempCsv.getName());
+      binaryContent.setFileName(fileName);
       binaryContent.setContentType("text/csv");
       binaryContent.setSize(tempCsv.length());
       binaryContentRepository.save(binaryContent);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/135-backup-file-name -> main

### 이슈 번호
- close #135 

### 변경 사항
- 기존 .csv 파일의 이름은 임시 파일을 만들기 위해 사용하였던 createTempFile때문에 랜덤값이 붙었음. 이를 해결하기 위해 파일 이름을 임시 파일 생성 후 따로 생성하여 저장함. 
- .log 파일이름은 날짜가 붙지 않아, 날짜와 시간까지 포함되게끔 변경.

### 테스트 결과
<img width="556" alt="image" src="https://github.com/user-attachments/assets/f244030e-9760-447f-8205-d7888fedb935" />

