### PR TITLE
[#137] 백업 N+1 예방 및 트랜젝션 설정

### DIFF
--- a/src/main/java/com/hrbank/entity/Backup.java
+++ b/src/main/java/com/hrbank/entity/Backup.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -42,7 +43,7 @@ public class Backup {
   @Column(nullable = false)
   private BackupStatus status;
 
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id")
   private BinaryContent file;
 

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -39,7 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class BasicBackupService implements BackupService {
@@ -52,6 +51,8 @@ public class BasicBackupService implements BackupService {
   private final BinaryContentStorage binaryContentStorage;
   private final EmployeeCsvGenerator employeeCsvGenerator;
 
+
+  @Transactional(readOnly = true)
   @Override
   public CursorPageResponseBackupDto searchBackups(
       String worker, BackupStatus status, LocalDateTime from, LocalDateTime to,
@@ -109,6 +110,7 @@ public class BasicBackupService implements BackupService {
     );
   }
 
+  @Transactional(readOnly = true)
   @Override
   public BackupDto findLatestBackupByStatus(BackupStatus status) {
     return backupRepository.findTopByStatusOrderByEndedAtDesc(status)
@@ -117,6 +119,7 @@ public class BasicBackupService implements BackupService {
   }
 
 
+  @Transactional
   @Override
   public BackupDto runBackup(String requesterIp) {
 
@@ -158,6 +161,7 @@ public class BasicBackupService implements BackupService {
 
     return inProgress;
   }
+
 
   private boolean isBackupRequired() {
     // 직원이 없으면 백업할 필요 X


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/137-backup-lazy-transaction -> main

### 이슈 번호
- close #137 

### 변경 사항
- BasicBackupService 클래스 레벨 @Transactional 제거
- 조회 메서드에 @Transactional(readOnly = true) 적용
- 쓰기 메서드에 @Transactional 적용
- Backup 엔티티의 file 연관관계 FetchType.LAZY 적용
- 필요할 때만 BinaryContent 조회
- 리스트 조회 성능 최적화 및 N+1 문제 방지
