### PR TITLE
[#138] 직원 수 추이 조회 수정

### DIFF
--- a/src/main/java/com/hrbank/dto/employee/EmployeeTrendDto.java
+++ b/src/main/java/com/hrbank/dto/employee/EmployeeTrendDto.java
@@ -1,20 +1,22 @@
 package com.hrbank.dto.employee;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-public class EmployeeTrendDto {
-  private String date;
-  private Long count;
-  private Long change;
-  private Double changeRate;
+import java.time.LocalDate;
+import lombok.Builder;
 
-  public EmployeeTrendDto(String date, Long count) {
-    this.date = date;
-    this.count = count;
-    this.change = 0L;
-    this.changeRate = 0.0;
+@Builder
+public record EmployeeTrendDto (
+    LocalDate date,
+    Long count,
+    Long change,
+    Double changeRate
+){
+  public static EmployeeTrendDto of(LocalDate date, Long count, Long change, Double changeRate) {
+    return EmployeeTrendDto.builder()
+        .date(date)
+        .count(count)
+        .change(change)
+        .changeRate(changeRate)
+        .build();
   }
 }

--- a/src/main/java/com/hrbank/generator/EmployeeCsvGenerator.java
+++ b/src/main/java/com/hrbank/generator/EmployeeCsvGenerator.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +29,11 @@ public class EmployeeCsvGenerator {
       propagation = Propagation.REQUIRES_NEW, isolation = Isolation.REPEATABLE_READ, readOnly = true
   )
   public File generate(BackupDto dto) throws IOException {
-    DateTimeFormatter fmt = DateTimeFormatter
-        .ofPattern("yyyyMMdd_HHmmss")
-        .withZone(ZoneId.of("Asia/Seoul"));
+    // 혹시 모르니 임시 파일도 유니크한 파일명으로 저장되도록 함.
+    DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
     String timestamp = fmt.format(dto.startedAt());
     String backupId = String.valueOf(dto.id());
-
-    File tempFile = File.createTempFile(
-        "employee_backup_" + backupId + "_" + timestamp,".csv");
+    File tempFile = File.createTempFile(backupId + "_" + timestamp,".csv");
 
     tempFile.deleteOnExit(); // JVM 종료 시 임시 파일 삭제(이중 대책)
 

--- a/src/main/java/com/hrbank/repository/EmployeeRepositoryImpl.java
+++ b/src/main/java/com/hrbank/repository/EmployeeRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.hrbank.entity.Employee;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -78,67 +79,71 @@ public class EmployeeRepositoryImpl implements EmployeeRepositoryCustom {
 
   @Override
   public List<EmployeeTrendDto> findEmployeeTrends(LocalDate from, LocalDate to, String unit) {
-    // 1. 그룹화 단위 및 기간 기본값 처리
-    String groupByUnit = (unit == null) ? "month" : unit;
-    LocalDate now = LocalDate.now();
-
-    if (from == null && to == null && "month".equals(groupByUnit)) {
-      from = now.minusMonths(12).withDayOfMonth(1); // 최근 12개월의 첫날
-      to = now.withDayOfMonth(now.lengthOfMonth());  // 이번달 마지막날
+    // 날짜(date) 저장 -> count세기 -> change세기 -> change Rate 구하기(직전의 count, 이번의 change 필요)
+    // 제일 옛날의 날짜(13개중 1번째) count와 change는 0과 0으로. changeRate도 0.0으로. 이전 cnt가 0이면 증감률 0.0으로 나와야 함.
+    // from이 null이면 unit기준 12개 이전부터 구해야 하고, 아니라면 to까지 unit기준으로 구해야 함. 어렵다;
+    if(to == null){
+      to = LocalDate.now();
+    }
+    if (from == null) {
+      switch (unit) {
+        case "year":
+          from = to.minusYears(12);
+          break;
+        case "quarter":
+          from = to.minusMonths(36);
+          break;
+        case "month":
+          from = to.minusMonths(12);
+          break;
+        case "week":
+          from = to.minusWeeks(12);
+          break;
+        case "day":
+        default:
+          from = to.minusDays(12);
+          break;
+      }
     }
 
-    // 2. 날짜 포맷
-    String dateFormat;
-    switch (groupByUnit) {
-      case "year": dateFormat = "TO_CHAR(e.hireDate, 'yyyy')"; break;
-      case "month": dateFormat = "TO_CHAR(e.hireDate, 'yyyy-MM')"; break;
-      case "quarter":
-        dateFormat = "CONCAT(TO_CHAR(e.hireDate, 'yyyy'), '-Q', " +
-            "(CASE WHEN EXTRACT(MONTH FROM e.hireDate) BETWEEN 1 AND 3 THEN 1 " +
-            "WHEN EXTRACT(MONTH FROM e.hireDate) BETWEEN 4 AND 6 THEN 2 " +
-            "WHEN EXTRACT(MONTH FROM e.hireDate) BETWEEN 7 AND 9 THEN 3 " +
-            "ELSE 4 END))";
-        break;
-      case "week":
-        dateFormat = "CONCAT(TO_CHAR(e.hireDate, 'yyyy'), '-W', EXTRACT(WEEK FROM e.hireDate))";
-        break;
-      default: dateFormat = "TO_CHAR(e.hireDate, 'yyyy-MM-dd')"; // day
+    List<EmployeeTrendDto> employeeTrendDtos = new ArrayList<>();
+    long prevCnt = 0L;
+    LocalDate current = from;
+    while(!current.isAfter(to)){
+      long currCnt = countEmployeesUntil(current);
+      long change = currCnt - prevCnt;
+      Double changeRate = (prevCnt == 0L) ? 0.0 : (change * 100.0 / prevCnt);
+
+      employeeTrendDtos.add(EmployeeTrendDto.of(current, currCnt, change, changeRate));
+
+      prevCnt = currCnt;
+      switch (unit) {
+        case "year":
+          current = current.plusYears(1);
+          break;
+        case "quarter":
+          current = current.plusMonths(3);
+          break;
+        case "month":
+          current = current.plusMonths(1);
+          break;
+        case "week":
+          current = current.plusWeeks(1);
+          break;
+        case "day":
+        default:
+          current = current.plusDays(1);
+          break;
+      }
     }
+    return employeeTrendDtos;
+  }
 
-    // 3. JPQL 동적 생성
-    String jpql = "SELECT new com.hrbank.dto.employee.EmployeeTrendDto(" +
-        dateFormat + ", " +
-        "COUNT(e.id)) " +
-        "FROM Employee e WHERE e.hireDate IS NOT NULL ";
-
-    //String jpql = "SELECT new com.hrbank.dto.employee.EmployeeTrendDto('2025-04', COUNT(e.id)) FROM Employee e WHERE e.hireDate IS NOT NULL ";
-
-
-    if (from != null) jpql += "AND e.hireDate >= :from ";
-    if (to != null) jpql += "AND e.hireDate <= :to ";
-
-    jpql += "GROUP BY " + dateFormat + " ORDER BY " + dateFormat + " DESC";
-
-    TypedQuery<EmployeeTrendDto> query = entityManager.createQuery(jpql, EmployeeTrendDto.class);
-    if (from != null) query.setParameter("from", from);
-    if (to != null) query.setParameter("to", to);
-//
-//    query.setFirstResult((int) pageable.getOffset());
-//    query.setMaxResults(pageable.getPageSize());
-
-    List<EmployeeTrendDto> trends = query.getResultList();
-
-    // 4. 증감/증감률 후처리
-    for (int i = 0; i < trends.size(); i++) {
-      EmployeeTrendDto current = trends.get(i);
-      Long prevCount = (i + 1 < trends.size()) ? trends.get(i + 1).getCount() : 0L;
-      long change = current.getCount() - prevCount;
-      double changeRate = prevCount == 0 ? 0.0 : (change * 100.0) / prevCount;
-      current.setChange(change);
-      current.setChangeRate(changeRate);
-    }
-
-    return trends;
+  private long countEmployeesUntil(LocalDate date){
+    String jpql = "SELECT COUNT(e) FROM Employee e WHERE e.hireDate <= :date";
+    return entityManager.createQuery(jpql, Long.class)
+        .setParameter("date", date)
+        .getSingleResult();
   }
 
   // 전체 결과 수를 계산하는 별도 메서드 (필터링된 직원 수 계산)

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -151,7 +151,7 @@ public class BasicBackupService implements BackupService {
 
     } catch (Exception e) {
       // 로그 파일 생성
-      Long logFileId = saveErrorLogFile(inProgress.id(), e);
+      Long logFileId = saveErrorLogFile(inProgress, e);
 
       // 실패 처리
       markBackupFailed(inProgress.id(), logFileId);
@@ -270,13 +270,18 @@ public class BasicBackupService implements BackupService {
     }
   }
 
-  private Long saveErrorLogFile(Long backupId, Exception e) {
+  private Long saveErrorLogFile(BackupDto dto, Exception e) {
     StringWriter sw = new StringWriter();
     e.printStackTrace(new PrintWriter(sw));
     String trace = sw.toString();
 
     BinaryContent binaryContent = new BinaryContent();
-    binaryContent.setFileName("backup_error_" + backupId + ".log");
+    DateTimeFormatter fmt = DateTimeFormatter
+        .ofPattern("yyyyMMdd_HHmmss");
+    String timestamp = fmt.format(dto.startedAt());
+    String backupId = String.valueOf(dto.id());
+
+    binaryContent.setFileName("backup_error_" + backupId + "_" + timestamp + ".log");
     binaryContent.setContentType("text/plain");
     binaryContent = binaryContentRepository.save(binaryContent);
     Long contentId = binaryContent.getId();

--- a/src/main/java/com/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicBackupService.java
@@ -24,6 +24,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -239,8 +240,14 @@ public class BasicBackupService implements BackupService {
     try{
       tempCsv = employeeCsvGenerator.generate(dto);
       binaryContentStorage.putCsvFile(contentId, tempCsv);
+      // 임시 파일 생성때의 이름을 쓰면 불필요한 랜덤값이 붙으니, 자체적으로 파일이름 생성.
+      DateTimeFormatter fmt = DateTimeFormatter
+          .ofPattern("yyyyMMdd_HHmmss");
+      String timestamp = fmt.format(dto.startedAt());
+      String backupId = String.valueOf(dto.id());
+      String fileName = "employee_backup_" + backupId + "_" + timestamp + ".csv";
 
-      binaryContent.setFileName(tempCsv.getName());
+      binaryContent.setFileName(fileName);
       binaryContent.setContentType("text/csv");
       binaryContent.setSize(tempCsv.length());
       binaryContentRepository.save(binaryContent);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/138-employees-trend-fix -> main

### 이슈 번호
- close #138 

### 변경 사항
- from이 null이었을 때, unit을 기준으로 총 13개의 EmployeeTrendDto가 생성되도록 변경.
- ✅ 실수로 main에서 브랜치를 생성하지 않아 다른 브랜치에서 변경한 이력이 포함되어있습니다. EmployeeRepositoryImpl와 EmployeeTrendDto만 확인해주세요.

### 테스트 결과
- 월별 직원 수 추이 결과
<img width="707" alt="변경_후_월별_추이" src="https://github.com/user-attachments/assets/62e0256f-3335-4c97-957f-088e7354b63c" />

- 분기별 직원 수 추이 결과
<img width="701" alt="변경_후_분기별_추이" src="https://github.com/user-attachments/assets/373587aa-f4d7-460a-a55c-ac7da80c19fe" />

나머지도 잘 실행됩니답