### PR TITLE
[#143] 변경 이력 날짜 필드를 LocalDateTime에서 OffsetDateTime으로 변경

### DIFF
--- a/src/main/java/com/hrbank/controller/EmployeeChangeLogController.java
+++ b/src/main/java/com/hrbank/controller/EmployeeChangeLogController.java
@@ -5,6 +5,7 @@ import com.hrbank.dto.employeeChangeLog.DiffDto;
 import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
 import com.hrbank.service.EmployeeChangeLogService;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -52,8 +53,8 @@ public class EmployeeChangeLogController {
 
   @GetMapping("/count")
   public ResponseEntity<Long> countChangeLogs(
-      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime fromDate,
-      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime toDate
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) OffsetDateTime fromDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) OffsetDateTime toDate
   ) {
     long count = changeLogService.countChangeLogs(fromDate, toDate);
     return ResponseEntity.ok(count);

--- a/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
+++ b/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
@@ -1,15 +1,15 @@
 package com.hrbank.dto.employeeChangeLog;
 
 import com.hrbank.enums.EmployeeChangeLogType;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public record EmployeeChangeLogSearchRequest(
     String employeeNumber,
     EmployeeChangeLogType type,
     String memo,
     String ipAddress,
-    LocalDateTime atFrom,
-    LocalDateTime atTo,
+    OffsetDateTime atFrom,
+    OffsetDateTime atTo,
     String sortField,
     String sortDirection
 ) {}

--- a/src/main/java/com/hrbank/repository/specification/EmployeeChangeLogSpecification.java
+++ b/src/main/java/com/hrbank/repository/specification/EmployeeChangeLogSpecification.java
@@ -3,7 +3,7 @@ package com.hrbank.repository.specification;
 import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
 import com.hrbank.entity.EmployeeChangeLog;
 import com.hrbank.enums.EmployeeChangeLogType;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import org.springframework.data.jpa.domain.Specification;
 
 public class EmployeeChangeLogSpecification {
@@ -34,11 +34,13 @@ public class EmployeeChangeLogSpecification {
         type == null ? null : cb.equal(root.get("type"), cb.literal(type));  // enum 타입으로 처리할 수 있도록
   }
 
-  public static Specification<EmployeeChangeLog> atBetween(LocalDateTime start, LocalDateTime end) {
-    return (root, query, cb) ->
-        (start == null || end == null)
-            ? null
-            : cb.between(root.get("at"), start, end);
+  public static Specification<EmployeeChangeLog> atBetween(OffsetDateTime start, OffsetDateTime end) {
+    return (root, query, cb) ->{
+      if (start == null || end == null) {
+        return null;
+      }
+      return cb.between(root.get("at"), start.toLocalDateTime(), end.toLocalDateTime());
+    };
   }
 
   // 검색을 위한 메서드

--- a/src/main/java/com/hrbank/service/EmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/EmployeeChangeLogService.java
@@ -5,6 +5,7 @@ import com.hrbank.dto.employeeChangeLog.DiffDto;
 import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
 import com.hrbank.entity.Employee;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface EmployeeChangeLogService {
@@ -20,5 +21,5 @@ public interface EmployeeChangeLogService {
 
   List<DiffDto> getChangeLogDetails(Long changeLogId);
 
-  long countChangeLogs(LocalDateTime fromDate, LocalDateTime toDate);
+  long countChangeLogs(OffsetDateTime fromDate, OffsetDateTime toDate);
 }

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
@@ -17,6 +17,7 @@ import com.hrbank.repository.EmployeeChangeLogRepository;
 import com.hrbank.repository.specification.EmployeeChangeLogSpecification;
 import com.hrbank.service.EmployeeChangeLogService;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -185,12 +186,12 @@ public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {
 
   @Override
   @Transactional(readOnly = true)
-  public long countChangeLogs(LocalDateTime fromDate, LocalDateTime toDate) {
-    LocalDateTime now = LocalDateTime.now();
+  public long countChangeLogs(OffsetDateTime fromDate, OffsetDateTime toDate) {
+    OffsetDateTime now = OffsetDateTime.now();
 
     // 기본값 설정
-    LocalDateTime start = (fromDate != null) ? fromDate : now.minusDays(7);
-    LocalDateTime end = (toDate != null) ? toDate : now;
+    OffsetDateTime start = (fromDate != null) ? fromDate : now.minusDays(7);
+    OffsetDateTime end = (toDate != null) ? toDate : now;
 
     if (start.isAfter(end)) {
       throw new RestException(ErrorCode.INVALID_DATE_RANGE);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/143-change-logs-datetime-to-offsetdatetime -> main

### 이슈 번호
- close #143

### 변경 사항
- EmployeeChangeLogSearchRequest의 atFrom, atTo 필드를 LocalDateTime → OffsetDateTime으로 변경
- atBetween 스펙 메서드가 OffsetDateTime을 받도록 수정하고 내부에서 LocalDateTime으로 변환
- Service와 Controller 모두 OffsetDateTime을 사용하도록 수정
- 프론트엔드에서 Z(UTC)가 포함된 ISO 8601 포맷 날짜를 정상적으로 받을 수 있도록 수정

### 테스트 결과
![image](https://github.com/user-attachments/assets/7df73c53-10aa-4a99-a3d8-120a6f96d5c7)
시작일/종료일을 선택하여도 정상 작동