### PR TITLE
[#155] EmployeeChangeLogController API 명세(Swagger) 추가 및 정리

### DIFF
--- a/src/main/java/com/hrbank/controller/EmployeeChangeLogController.java
+++ b/src/main/java/com/hrbank/controller/EmployeeChangeLogController.java
@@ -1,5 +1,6 @@
 package com.hrbank.controller;
 
+import com.hrbank.controller.api.EmployeeChangeLogControllerApi;
 import com.hrbank.dto.employeeChangeLog.CursorPageResponseChangeLogDto;
 import com.hrbank.dto.employeeChangeLog.DiffDto;
 import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
@@ -20,18 +21,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/change-logs")
 @RequiredArgsConstructor
-public class EmployeeChangeLogController {
+public class EmployeeChangeLogController implements EmployeeChangeLogControllerApi {
 
   private final EmployeeChangeLogService changeLogService;
-
-  @GetMapping("/exists")
-  public ResponseEntity<Boolean> hasChangedSince(
-      @RequestParam("since") @DateTimeFormat(iso = ISO.DATE_TIME) OffsetDateTime since) {
-    // http://localhost:8080/api/change-logs/exists?since=2025-04-22T00:00:00
-    // 특정 시점 이후 변경된 내용이 있으면 true, 없으면 false를 반환합니다.
-    return ResponseEntity.ok(changeLogService.hasChangeSince(since));
-  }
-
 
   @GetMapping
   public ResponseEntity<CursorPageResponseChangeLogDto> getChangeLogs(

--- a/src/main/java/com/hrbank/controller/api/EmployeeChangeLogControllerApi.java
+++ b/src/main/java/com/hrbank/controller/api/EmployeeChangeLogControllerApi.java
@@ -1,0 +1,67 @@
+package com.hrbank.controller.api;
+
+import com.hrbank.dto.employeeChangeLog.CursorPageResponseChangeLogDto;
+import com.hrbank.dto.employeeChangeLog.DiffDto;
+import com.hrbank.dto.employeeChangeLog.EmployeeChangeLogSearchRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "직원 정보 수정 이력 관리", description = "직원 변경 이력 관리 API")
+public interface EmployeeChangeLogControllerApi {
+
+  @Operation(summary = "직원 변경 이력 목록 조회", description = "직원 변경 이력 목록을 검색합니다. 상세 변경 내용은 포함되지 않습니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = CursorPageResponseChangeLogDto.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 지원하지 않는 정렬 필드", content = @Content(examples = @ExampleObject(value = "{\"errorCode\": \"400\", \"message\": \"잘못된 요청입니다.\"}"))),
+      @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(examples = @ExampleObject(value = "{\"errorCode\": \"500\", \"message\": \"서버 오류가 발생했습니다.\"}")))
+  })
+  ResponseEntity<CursorPageResponseChangeLogDto> getChangeLogs(
+      @Parameter(description = "검색 조건", content = @Content(schema = @Schema(implementation = EmployeeChangeLogSearchRequest.class)))
+      @ModelAttribute EmployeeChangeLogSearchRequest request,
+
+      @Parameter(description = "이전 페이지 마지막 ID")
+      @RequestParam(required = false) Long idAfter,
+
+      @Parameter(description = "커서 (이전 페이지 마지막 요소 ID)")
+      @RequestParam(required = false) String cursor,
+
+      @Parameter(description = "페이지 크기")
+      @RequestParam(defaultValue = "10") int size
+  );
+
+  @Operation(summary = "변경 이력 상세 조회", description = "특정 변경 이력 ID에 대한 상세 변경 내용을 조회합니다. 변경 상세 내용이 포함됩니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = DiffDto.class))),
+      @ApiResponse(responseCode = "404", description = "이력을 찾을 수 없음", content = @Content(examples = @ExampleObject(value = "{\"errorCode\": \"404\", \"message\": \"이력을 찾을 수 없습니다.\"}"))),
+      @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(examples = @ExampleObject(value = "{\"errorCode\": \"500\", \"message\": \"서버 오류가 발생했습니다.\"}")))
+  })
+  ResponseEntity<List<DiffDto>> getChangeLogDiffs(
+      @Parameter(description = "이력 ID") Long id
+  );
+
+  @Operation(summary = "변경 이력 건수 조회", description = "직원 정보 수정 이력 건수를 조회합니다. 파라미터를 제공하지 않으면 최근 일주일 데이터를 반환합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = Long.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 유효하지 않은 날짜 범위", content = @Content(examples = @ExampleObject(value = "{\"errorCode\": \"400\", \"message\": \"잘못된 날짜입니다.\"}"))),
+      @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(examples = @ExampleObject(value = "{\"errorCode\": \"500\", \"message\": \"서버 오류가 발생했습니다.\"}")))
+  })
+  ResponseEntity<Long> countChangeLogs(
+      @Parameter(description = "시작 일시(기본값: 7일 전)")
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime fromDate,
+
+      @Parameter(description = "종료 일시(기본값: 현재)")
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime toDate
+  );
+}

--- a/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
+++ b/src/main/java/com/hrbank/dto/employeeChangeLog/EmployeeChangeLogSearchRequest.java
@@ -1,15 +1,31 @@
 package com.hrbank.dto.employeeChangeLog;
 
 import com.hrbank.enums.EmployeeChangeLogType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
 
 public record EmployeeChangeLogSearchRequest(
+    @Schema(description = "대상 직원 사번", example = "EMP001")
     String employeeNumber,
+
+    @Schema(description = "이력 유형", example = "UPDATED")
     EmployeeChangeLogType type,
+
+    @Schema(description = "내용", example = "주소 변경")
     String memo,
+
+    @Schema(description = "IP 주소", example = "192.168.1.1")
     String ipAddress,
+
+    @Schema(description = "수정 일시(부터)", example = "2025-04-20T00:00:00Z")
     OffsetDateTime atFrom,
+
+    @Schema(description = "수정 일시(까지)", example = "2025-04-27T23:59:59Z")
     OffsetDateTime atTo,
+
+    @Schema(description = "정렬 필드 (ipAddress, at)", example = "at")
     String sortField,
+
+    @Schema(description = "정렬 방향 (asc, desc)", example = "desc")
     String sortDirection
 ) {}

--- a/src/main/java/com/hrbank/service/EmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/EmployeeChangeLogService.java
@@ -12,9 +12,6 @@ public interface EmployeeChangeLogService {
   // 변경점 로그 저장
   void saveChangeLog(Employee employeeBefore, Employee employeeAfter, String memo, String ip);
 
-  //  특성 시점 이후 변경된 내용이 있는지 확인
-  boolean hasChangeSince(OffsetDateTime at);
-
   // 이력 목록 조회
   CursorPageResponseChangeLogDto search(EmployeeChangeLogSearchRequest request, Long idAfter, String cursor, int size);
 

--- a/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
+++ b/src/main/java/com/hrbank/service/basic/BasicEmployeeChangeLogService.java
@@ -117,12 +117,6 @@ public class BasicEmployeeChangeLogService implements EmployeeChangeLogService {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean hasChangeSince(OffsetDateTime at) {
-    return changeLogRepository.existsByAtAfter(at);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public CursorPageResponseChangeLogDto search(EmployeeChangeLogSearchRequest request, Long idAfter, String cursor, int size) {
     Long resolvedIdAfter = idAfter;
     // cursor가 있으면 우선적으로 사용


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/155-add-employee-change-log-api-docs -> main

### 이슈 번호
- close #155

### 변경 사항
- API 요청 파라미터와 응답 스펙을 Swagger UI에 명확히 표시
- 사용하지 않는 hasChangeSince 메서드 제거