### PR TITLE
fix: EmployeeMapper에서 departmentId 매핑 누락 수정(재업로드)

### DIFF
--- a/src/main/java/com/hrbank/mapper/EmployeeMapper.java
+++ b/src/main/java/com/hrbank/mapper/EmployeeMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.Mapping;
 public interface EmployeeMapper {
   @Mapping(source = "department.name", target = "departmentName")
   @Mapping(source = "profileImage.id", target = "profileImageId")
+  @Mapping(source = "department.id", target = "departmentId")
   EmployeeDto toDto(Employee employee);
   List<EmployeeDto> toDtoList(List<Employee> employees);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/employee-mapper-departmentid-mapping-pull -> main

### 이슈 번호
- close #이슈 번호

### 변경 사항
- `@Mapping(source = "department.id", target = "departmentId")` 어노테이션을 추가하여 누락된 매핑을 보완했습니다.
- 해당 수정으로 컴파일 경고 및 충돌 문제를 해결했습니다.

