### PR TITLE
feat: 서버 포트 설정 추가 및 FrontendController 추가로 SPA 경로 대응

### DIFF
--- a/src/main/java/com/hrbank/controller/FrontendController.java
+++ b/src/main/java/com/hrbank/controller/FrontendController.java
@@ -1,0 +1,22 @@
+package com.hrbank.controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+// 없는 경로 요청을 모두 index.html으로 포워딩하는 로직
+@Controller
+public class FrontendController {
+
+  @GetMapping(value = {
+      "/",
+      "/dashboard",
+      "/departments",
+      "/employees",
+      "/change-logs",
+      "/backups"
+  })
+  public String forwardToFrontend() {
+    return "forward:/index.html";
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,9 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
 
+server:
+  port: ${PORT:8080}  # ✅ 이 줄 추가!
+
 hrbank:
   storage:
     type: local


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
main -> main

### 변경 사항
- application.yml 파일에 서버 포트(port) 설정 추가 (`server.port: ${PORT:8080}`)
- FrontendController 추가하여 SPA(Single Page Application) 경로 새로고침 및 직접 접근 시 정상적으로 index.html 반환 처리

### 상세 설명
- 기존에는 /departments, /employees 등 경로를 직접 입력하거나 새로고침하면 서버가 정적 파일을 찾으려고 하면서 500 에러가 발생했습니다.
- 이를 해결하기 위해 FrontendController를 추가하여, 주요 프론트 경로 요청은 index.html로 포워딩하고 이후 프론트엔드 라우터가 경로를 해석하도록 변경했습니다.
- 추가로 application.yml 파일에 server.port를 환경변수 기반으로 설정하여 Railway와 같은 배포 환경에서도 포트 지정이 가능하도록 수정했습니다.

### 기타
- 기능상 변경은 없으며, 초기 진입 및 경로 이동 안정성 향상을 위한 설정입니다.
